### PR TITLE
Bootstrap minimal Python package and CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: ci
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip setuptools wheel
+      - run: pip install -e .
+      - run: python -m vision --version
+      - run: vision --version

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # vision
 
+A minimal Python package with a command-line interface stub.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## Usage
+
+```bash
+python -m vision --version
+vision --version
+```
+
+Both commands output `Vision 0.0.1`.
+
+For more options, run:
+
+```bash
+python -m vision --help
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vision"
+version = "0.0.1"
+description = "vision package"
+authors = [{name = "Vision Authors", email = "dev@example.com"}]
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+
+[project.scripts]
+vision = "vision.cli:main"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[options]
+package_dir =
+    =src
+packages = find:
+
+[options.packages.find]
+where = src

--- a/src/vision/__init__.py
+++ b/src/vision/__init__.py
@@ -1,0 +1,4 @@
+"""Top-level package for vision."""
+
+__all__ = ["__version__"]
+__version__ = "0.0.1"

--- a/src/vision/__main__.py
+++ b/src/vision/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/vision/cli.py
+++ b/src/vision/cli.py
@@ -1,0 +1,38 @@
+"""Command-line interface for vision."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Sequence
+
+from . import __version__
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the CLI."""
+    parser = argparse.ArgumentParser(
+        prog="vision",
+        description="Vision CLI"
+    )
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the version and exit.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the main program."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.version:
+        print(f"Vision {__version__}")
+    else:
+        parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from vision.cli import main
+from vision import __version__
+
+
+def test_version_prints_package_version(capsys):
+    assert main(["--version"]) == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() == f"Vision {__version__}"


### PR DESCRIPTION
## Summary
- configure setuptools-based build with a `src` layout and expose a `vision` console script
- add a CLI that shows a "Vision CLI" banner and prints `Vision 0.0.1` via `python -m vision --version` and `vision --version`
- document usage and provide CI to install and run the version commands

## Testing
- `python -m pip install --upgrade pip setuptools wheel` *(fails: Could not find a version that satisfies the requirement setuptools)*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `python -m vision --version` *(fails: No module named vision)*
- `vision --version` *(fails: command not found: vision)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vision')*

------
https://chatgpt.com/codex/tasks/task_e_68af7e5de7a88328aa95f537ac7060b5