### PR TITLE
feat: add fake detector CLI flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,4 @@ jobs:
       - run: python -m vision --version
       - run: vision --version
       - run: vision webcam --dry-run
+      - run: vision webcam --use-fake-detector --dry-run

--- a/README.md
+++ b/README.md
@@ -29,8 +29,35 @@ For headless environments or continuous integration, use the dry run:
 vision webcam --dry-run
 ```
 
+To exercise the fake detector instead of the built-in rectangle, use:
+
+```bash
+vision webcam --use-fake-detector
+```
+
+The fake detector can also run in a dry run without requiring OpenCV:
+
+```bash
+vision webcam --use-fake-detector --dry-run
+```
+
+which prints ``Dry run: fake detector produced 1 boxes``.
+
 For more options, run:
 
 ```bash
 python -m vision --help
+```
+
+## Fake detector stub
+
+The package includes a very small :class:`FakeDetector` that always
+returns the same bounding box.  It is a placeholder for future detection
+work and can be imported with:
+
+```python
+from vision.fake_detector import FakeDetector
+
+detector = FakeDetector()
+detector.detect(None)  # -> [(50, 50, 200, 200)]
 ```

--- a/src/vision/__init__.py
+++ b/src/vision/__init__.py
@@ -1,4 +1,6 @@
 """Top-level package for vision."""
 
-__all__ = ["__version__"]
+from .fake_detector import FakeDetector
+
 __version__ = "0.0.1"
+__all__ = ["__version__", "FakeDetector"]

--- a/src/vision/cli.py
+++ b/src/vision/cli.py
@@ -25,6 +25,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip the webcam loop and print a message instead.",
     )
+    webcam_parser.add_argument(
+        "--use-fake-detector",
+        action="store_true",
+        help="Run the webcam loop with the FakeDetector stub.",
+    )
     return parser
 
 
@@ -36,7 +41,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.version:
         print(f"Vision {__version__}")
     elif args.command == "webcam":
-        webcam.loop(dry_run=args.dry_run)
+        webcam.loop(dry_run=args.dry_run, use_fake=args.use_fake_detector)
     else:
         parser.print_help()
     return 0

--- a/src/vision/fake_detector.py
+++ b/src/vision/fake_detector.py
@@ -1,0 +1,28 @@
+"""Fake object detector stub."""
+
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+
+class FakeDetector:
+    """A stub detector that returns a fixed bounding box.
+
+    This placeholder mimics a real detector by always returning the same
+    bounding box regardless of the input frame.
+    """
+
+    def detect(self, frame: Any) -> List[Tuple[int, int, int, int]]:
+        """Return a list containing a single dummy bounding box.
+
+        Parameters
+        ----------
+        frame:
+            Ignored input representing an image frame.
+
+        Returns
+        -------
+        list of tuple of int
+            A list with one bounding box in ``(x1, y1, x2, y2)`` format.
+        """
+        return [(50, 50, 200, 200)]

--- a/src/vision/webcam.py
+++ b/src/vision/webcam.py
@@ -2,14 +2,19 @@
 
 from __future__ import annotations
 
+from .fake_detector import FakeDetector
 
-def loop(*, dry_run: bool = False) -> int:
+
+def loop(*, dry_run: bool = False, use_fake: bool = False) -> int:
     """Run the webcam capture loop.
 
     Parameters
     ----------
     dry_run:
         If ``True``, the loop is skipped and a message is printed instead.
+    use_fake:
+        Whether to run the :class:`FakeDetector` rather than draw a
+        hard-coded rectangle.
 
     Returns
     -------
@@ -18,10 +23,19 @@ def loop(*, dry_run: bool = False) -> int:
     """
 
     if dry_run:
+        if use_fake:
+            detector = FakeDetector()
+            boxes = detector.detect(None)
+            print(f"Dry run: fake detector produced {len(boxes)} boxes")
+            return 0
         print("Dry run: webcam loop skipped")
         return 0
 
     import cv2  # Import lazily so dry runs do not require OpenCV
+
+    detector: FakeDetector | None = None
+    if use_fake:
+        detector = FakeDetector()
 
     cap = cv2.VideoCapture(0)
     if not cap.isOpened():
@@ -35,7 +49,12 @@ def loop(*, dry_run: bool = False) -> int:
                 print("Error: failed to read frame")
                 break
 
-            cv2.rectangle(frame, (50, 50), (200, 200), (0, 255, 0), 2)
+            if use_fake and detector is not None:
+                for x1, y1, x2, y2 in detector.detect(frame):
+                    cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
+            else:
+                cv2.rectangle(frame, (50, 50), (200, 200), (0, 255, 0), 2)
+
             cv2.imshow("Vision Stub", frame)
 
             if cv2.waitKey(1) & 0xFF == ord("q"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,3 +14,9 @@ def test_webcam_command_supports_dry_run(capsys):
     assert main(["webcam", "--dry-run"]) == 0
     captured = capsys.readouterr()
     assert captured.out.strip() == "Dry run: webcam loop skipped"
+
+
+def test_webcam_fake_detector_dry_run(capsys):
+    assert main(["webcam", "--use-fake-detector", "--dry-run"]) == 0
+    out = capsys.readouterr().out.strip()
+    assert out == "Dry run: fake detector produced 1 boxes"

--- a/tests/test_fake_detector.py
+++ b/tests/test_fake_detector.py
@@ -1,0 +1,6 @@
+from vision.fake_detector import FakeDetector
+
+
+def test_fake_detector_returns_fixed_box():
+    detector = FakeDetector()
+    assert detector.detect(object()) == [(50, 50, 200, 200)]


### PR DESCRIPTION
## Summary
- add `--use-fake-detector` option to webcam CLI and integrate with loop
- support dry-run mode without OpenCV and document usage
- exercise fake detector in CI and tests

## Testing
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python -m vision webcam --use-fake-detector --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68af8df072f08328a707a58331a7e6ad