### PR TITLE
Add cluster store with JSON persistence and integrate with webcam

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The fake detector can also run in a dry run without requiring OpenCV:
 vision webcam --use-fake-detector --dry-run
 ```
 
-which prints ``Dry run: fake detector produced 1 boxes, tracker assigned IDs, embedder produced 1 embeddings``.
+which prints ``Dry run: fake detector produced 1 boxes, tracker assigned IDs, embedder produced 1 embeddings, cluster store prepared 1 exemplar``.
 
 For more options, run:
 
@@ -87,4 +87,38 @@ from vision.embedder import Embedder
 
 embedder = Embedder()
 embedder.embed(None)  # -> [0.0] * 128
+```
+
+## Cluster store stub
+
+The package provides a :class:`ClusterStore` placeholder that persists
+*exemplar* records to ``data/kb.json`` by default. An exemplar has the
+following fields:
+
+```json
+{
+  "label": "unknown",
+  "bbox": [x1, y1, x2, y2],
+  "embedding": [0.0, ... 128 floats ...],
+  "provenance": {"source": "fake", "ts": "<ISO8601>", "note": "stub"}
+}
+```
+
+Dry runs of the webcam (``vision webcam --use-fake-detector --dry-run``)
+do not write to disk, while live runs with ``--use-fake-detector`` append an
+exemplar per frame and flush the store.
+
+```python
+from vision.cluster_store import ClusterStore
+
+store = ClusterStore()  # persists to data/kb.json
+store.add_exemplar(
+    "unknown",
+    (1, 2, 3, 4),
+    [0.0] * 128,
+    {"source": "fake", "ts": "2025-01-01T00:00:00Z", "note": "stub"},
+)
+store.flush()
+# Later
+reloaded = ClusterStore.load("data/kb.json")
 ```

--- a/src/vision/cluster_store.py
+++ b/src/vision/cluster_store.py
@@ -1,0 +1,75 @@
+"""Cluster store stub with JSON persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Dict, List
+
+
+class ClusterStore:
+    """A stub cluster store that records embeddings by cluster ID.
+
+    In addition to the simple in-memory API used for early experiments, the
+    store can persist *exemplar* records to disk in a small JSON file.  Each
+    exemplar contains a label, bounding box, embedding vector and provenance
+    information.
+    """
+
+    def __init__(self, path: str | Path = "data/kb.json") -> None:
+        self._store: Dict[int, List[List[float]]] = {}
+
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._data = {"exemplars": []}
+
+    # ------------------------------------------------------------------
+    # Backwards compatible in-memory API
+    def add(self, cluster_id: int, embedding: List[float]) -> None:
+        """Add an embedding to the cluster identified by ``cluster_id``."""
+        self._store.setdefault(cluster_id, []).append(embedding)
+
+    def get(self, cluster_id: int) -> List[List[float]]:
+        """Return a list of embeddings for ``cluster_id``.
+
+        If the cluster ID has not been seen before, an empty list is returned.
+        """
+        return list(self._store.get(cluster_id, []))
+
+    # ------------------------------------------------------------------
+    # Exemplar persistence API
+    def add_exemplar(
+        self,
+        label: str,
+        bbox: tuple[int, int, int, int],
+        embedding: List[float],
+        provenance: dict,
+    ) -> None:
+        """Append an exemplar description to the in-memory buffer."""
+
+        self._data["exemplars"].append(
+            {
+                "label": label,
+                "bbox": list(bbox),
+                "embedding": list(embedding),
+                "provenance": provenance,
+            }
+        )
+
+    def flush(self) -> None:
+        """Atomically persist the current exemplars to disk."""
+
+        with NamedTemporaryFile("w", delete=False, dir=self._path.parent) as tmp:
+            json.dump(self._data, tmp, ensure_ascii=False, indent=2)
+        Path(tmp.name).replace(self._path)
+
+    @classmethod
+    def load(cls, path: str | Path) -> "ClusterStore":
+        """Load existing exemplars from ``path`` if it exists."""
+
+        p = Path(path)
+        store = cls(p)
+        if p.exists():
+            store._data = json.loads(p.read_text())
+        return store

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,10 +16,10 @@ def test_webcam_command_supports_dry_run(capsys):
     assert captured.out.strip() == "Dry run: webcam loop skipped"
 
 
-def test_webcam_fake_detector_tracker_dry_run(capsys):
+def test_webcam_fake_detector_dry_run_includes_cluster_store(capsys):
     assert main(["webcam", "--use-fake-detector", "--dry-run"]) == 0
     out = capsys.readouterr().out.strip()
-    assert (
-        out
-        == "Dry run: fake detector produced 1 boxes, tracker assigned IDs, embedder produced 1 embeddings"
+    assert out == (
+        "Dry run: fake detector produced 1 boxes, tracker assigned IDs, "
+        "embedder produced 1 embeddings, cluster store prepared 1 exemplar"
     )

--- a/tests/test_cluster_store.py
+++ b/tests/test_cluster_store.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+from vision.cluster_store import ClusterStore
+
+
+def test_cluster_store_persists_exemplars(tmp_path):
+    path = tmp_path / "kb.json"
+    store = ClusterStore(path)
+    emb = [0.0] * 128
+    bbox = (1, 2, 3, 4)
+    prov = {"source": "fake", "ts": "2025-01-01T00:00:00Z", "note": "stub"}
+    store.add_exemplar("unknown", bbox, emb, prov)
+    store.flush()
+
+    data = json.loads(path.read_text())
+    assert "exemplars" in data and len(data["exemplars"]) == 1
+    ex = data["exemplars"][0]
+    assert ex["label"] == "unknown"
+    assert ex["bbox"] == list(bbox)
+    assert ex["embedding"] == emb
+    assert ex["provenance"]["source"] == "fake"
+    assert "ts" in ex["provenance"]
+
+    # Load again
+    reloaded = ClusterStore.load(path)
+    # Reloaded store should reflect the same exemplar count
+    assert len(json.loads(Path(path).read_text())["exemplars"]) == 1


### PR DESCRIPTION
## Summary
- persist exemplars to JSON using ClusterStore with `add_exemplar`, `flush`, and `load`
- integrate ClusterStore into fake-detector webcam loop, collecting provenance and flushing per frame
- standardize dry-run output and document exemplar schema and behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af9bbeaecc8328b42515641657256a