### PR TITLE
Add labeler stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The fake detector can also run in a dry run without requiring OpenCV:
 vision webcam --use-fake-detector --dry-run
 ```
 
-which prints ``Dry run: fake detector produced 1 boxes, tracker assigned IDs, embedder produced 1 embeddings, cluster store prepared 1 exemplar, matcher compared embeddings (stub)``.
+which prints ``Dry run: fake detector produced 1 boxes, tracker assigned IDs, embedder produced 1 embeddings, cluster store prepared 1 exemplar, matcher compared embeddings (stub), labeler assigned 'unknown'``.
 
 For more options, run:
 
@@ -103,8 +103,20 @@ matcher.match([1.0, 2.0], [[1.0, 2.0], [3.0, 4.0]])  # -> 0
 matcher.match([5.0], [])  # -> -1
 ```
 
-Dry runs of the webcam now report ``matcher compared embeddings (stub)`` to
-indicate the matcher was invoked.
+Dry runs of the webcam now report ``matcher compared embeddings (stub), labeler assigned 'unknown'`` to
+indicate the matcher and labeler were invoked.
+
+## Labeler stub
+
+The package includes a small :class:`Labeler` placeholder that always
+returns the label ``"unknown"``.
+
+```python
+from vision import Labeler
+
+labeler = Labeler()
+labeler.label(None)  # -> "unknown"
+```
 
 ## Cluster store stub
 

--- a/src/vision/__init__.py
+++ b/src/vision/__init__.py
@@ -3,6 +3,7 @@
 from .fake_detector import FakeDetector
 from .embedder import Embedder
 from .matcher import Matcher
+from .labeler import Labeler
 
 __version__ = "0.0.1"
-__all__ = ["__version__", "FakeDetector", "Embedder", "Matcher"]
+__all__ = ["__version__", "FakeDetector", "Embedder", "Matcher", "Labeler"]

--- a/src/vision/labeler.py
+++ b/src/vision/labeler.py
@@ -1,0 +1,28 @@
+"""Labeler stub."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Labeler:
+    """A stub labeler that returns a fixed label.
+
+    This placeholder mimics a real labeling model by always returning
+    the same label regardless of the input provided.
+    """
+
+    def label(self, embedding: Any) -> str:
+        """Return a dummy label.
+
+        Parameters
+        ----------
+        embedding:
+            Ignored input representing an embedding or other data.
+
+        Returns
+        -------
+        str
+            The fixed label ``"unknown"``.
+        """
+        return "unknown"

--- a/src/vision/webcam.py
+++ b/src/vision/webcam.py
@@ -9,6 +9,7 @@ from .tracker import Tracker
 from .embedder import Embedder
 from .cluster_store import ClusterStore
 from .matcher import Matcher
+from .labeler import Labeler
 
 
 def loop(*, dry_run: bool = False, use_fake: bool = False) -> int:
@@ -34,15 +35,18 @@ def loop(*, dry_run: bool = False, use_fake: bool = False) -> int:
             tracker = Tracker()
             embedder = Embedder()
             matcher = Matcher()
+            labeler = Labeler()
             boxes = detector.detect(None)
             tracked = tracker.update(boxes)
             embeddings = [embedder.embed(box) for _, box in tracked]
             _ = matcher.match(embeddings[0], embeddings) if embeddings else -1
+            _ = labeler.label(embeddings[0]) if embeddings else "unknown"
             print(
                 "Dry run: fake detector produced "
                 f"{len(boxes)} boxes, tracker assigned IDs, "
                 f"embedder produced {len(embeddings)} embeddings, "
-                "cluster store prepared 1 exemplar, matcher compared embeddings (stub)"
+                "cluster store prepared 1 exemplar, matcher compared embeddings (stub), "
+                "labeler assigned 'unknown'"
             )
             return 0
         print("Dry run: webcam loop skipped")
@@ -55,12 +59,14 @@ def loop(*, dry_run: bool = False, use_fake: bool = False) -> int:
     embedder: Embedder | None = None
     store: ClusterStore | None = None
     matcher: Matcher | None = None
+    labeler: Labeler | None = None
     if use_fake:
         detector = FakeDetector()
         tracker = Tracker()
         embedder = Embedder()
         store = ClusterStore()
         matcher = Matcher()
+        labeler = Labeler()
 
     cap = cv2.VideoCapture(0)
     if not cap.isOpened():
@@ -81,25 +87,35 @@ def loop(*, dry_run: bool = False, use_fake: bool = False) -> int:
                 and embedder is not None
                 and store is not None
                 and matcher is not None
+                and labeler is not None
             ):
                 boxes = detector.detect(frame)
                 tracked = tracker.update(boxes)
                 for tid, (x1, y1, x2, y2) in tracked:
                     embedding = embedder.embed((x1, y1, x2, y2))
                     _ = matcher.match(embedding, [])
+                    label = labeler.label(embedding)
                     provenance = {
                         "source": "fake",
                         "ts": datetime.now(timezone.utc).isoformat(),
                         "note": "stub",
                     }
-                    store.add_exemplar(
-                        "unknown", (x1, y1, x2, y2), embedding, provenance
-                    )
+                    store.add_exemplar(label, (x1, y1, x2, y2), embedding, provenance)
                     cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
                     cv2.putText(
                         frame,
                         f"ID {tid}",
                         (x1, max(0, y1 - 8)),
+                        cv2.FONT_HERSHEY_SIMPLEX,
+                        0.5,
+                        (0, 255, 0),
+                        1,
+                        cv2.LINE_AA,
+                    )
+                    cv2.putText(
+                        frame,
+                        f"Label {label}",
+                        (x1, min(y2 + 16, frame.shape[0] - 5)),
                         cv2.FONT_HERSHEY_SIMPLEX,
                         0.5,
                         (0, 255, 0),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,11 +16,11 @@ def test_webcam_command_supports_dry_run(capsys):
     assert captured.out.strip() == "Dry run: webcam loop skipped"
 
 
-def test_webcam_fake_detector_dry_run_includes_matcher(capsys):
+def test_webcam_fake_detector_dry_run_includes_labeler(capsys):
     assert main(["webcam", "--use-fake-detector", "--dry-run"]) == 0
     out = capsys.readouterr().out.strip()
     assert out == (
         "Dry run: fake detector produced 1 boxes, tracker assigned IDs, "
         "embedder produced 1 embeddings, cluster store prepared 1 exemplar, "
-        "matcher compared embeddings (stub)"
+        "matcher compared embeddings (stub), labeler assigned 'unknown'"
     )

--- a/tests/test_labeler.py
+++ b/tests/test_labeler.py
@@ -1,0 +1,6 @@
+from vision import Labeler
+
+
+def test_labeler_returns_unknown_label():
+    labeler = Labeler()
+    assert labeler.label(object()) == "unknown"


### PR DESCRIPTION
## Summary
- integrate `Labeler` into fake-detector webcam paths
- document labeler usage and extend dry-run output
- verify new dry-run string in CLI test

## Testing
- `pytest`
- `PYTHONPATH=src python -m vision webcam --use-fake-detector --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68afa70e207083289657b07ada0de381