### PR TITLE
docs: backfill charter and add markdown lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
           python-version: "3.11"
       - run: python -m pip install --upgrade pip setuptools wheel
       - run: pip install -e .
+      - name: Lint Markdown
+        uses: avto-dev/markdown-lint@v1
+        with:
+          args: '**/*.md'
       - run: python -m vision --version
       - run: vision --version
       - run: vision webcam --dry-run

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+data/

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,5 @@
+---
+default: true
+MD013: false   # line length off for now
+MD033: false   # allow inline HTML if present
+---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+We welcome small, focused pull requests.
+
+## Getting Started
+- Create a virtual environment and install the package in editable mode.
+- Run tests with `pytest` before submitting.
+- Exercise the CLI dry-run via `vision webcam --use-fake-detector --dry-run`.
+- External network calls (RIS) are deferred until future milestones.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Vision Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A minimal Python package with a command-line interface stub.
 
+## MVP Definition & Success Metrics
+- Latency P95 ≤ 800ms @720p
+- Pipeline initializes in ≤2s
+- Dry run completes without errors
+
 ## Installation
 
 ```bash
@@ -11,11 +16,10 @@ pip install -e .
 ## Usage
 
 ```bash
-python -m vision --version
 vision --version
 ```
 
-Both commands output `Vision 0.0.1`.
+This prints `Vision 0.0.1`.
 
 To test the webcam integration, run the live loop:
 
@@ -29,30 +33,23 @@ For headless environments or continuous integration, use the dry run:
 vision webcam --dry-run
 ```
 
+which prints `Dry run: webcam loop skipped`.
+
 To exercise the fake detector instead of the built-in rectangle, use:
-
-```bash
-vision webcam --use-fake-detector
-```
-
-This overlays stub tracker IDs over the detected box and runs the stub
-embedder for each detection.
-
-The fake detector can also run in a dry run without requiring OpenCV:
 
 ```bash
 vision webcam --use-fake-detector --dry-run
 ```
 
-which prints ``Dry run: fake detector produced 1 boxes, tracker assigned IDs, embedder produced 1 embeddings, cluster store prepared 1 exemplar, matcher compared embeddings (stub), labeler assigned 'unknown'``.
+which prints `Dry run: fake detector produced 1 boxes, tracker assigned IDs, embedder produced 1 embeddings, cluster store prepared 1 exemplar, matcher compared embeddings (stub), labeler assigned 'unknown'`.
 
 For more options, run:
 
 ```bash
-python -m vision --help
+vision --help
 ```
 
-## Fake detector stub
+## Fake Detector
 
 The package includes a very small :class:`FakeDetector` that always
 returns the same bounding box.  It is a placeholder for future detection
@@ -65,7 +62,7 @@ detector = FakeDetector()
 detector.detect(None)  # -> [(50, 50, 200, 200)]
 ```
 
-## Tracker stub
+## Tracker
 
 The package also ships with a tiny :class:`Tracker` placeholder that assigns
 incremental IDs to bounding boxes.
@@ -77,7 +74,7 @@ tracker = Tracker()
 tracker.update([(50, 50, 200, 200)])  # -> [(1, (50, 50, 200, 200))]
 ```
 
-## Embedder stub
+## Embedder
 
 The package also contains an :class:`Embedder` placeholder that always
 returns the same 128-dimensional feature vector.
@@ -89,7 +86,7 @@ embedder = Embedder()
 embedder.embed(None)  # -> [0.0] * 128
 ```
 
-## Matcher stub
+## Matcher
 
 The package provides a simple :class:`Matcher` placeholder that searches for
 an embedding within a list of candidates and reports the index of the first
@@ -106,19 +103,19 @@ matcher.match([5.0], [])  # -> -1
 Dry runs of the webcam now report ``matcher compared embeddings (stub), labeler assigned 'unknown'`` to
 indicate the matcher and labeler were invoked.
 
-## Labeler stub
+## Labeler
 
 The package includes a small :class:`Labeler` placeholder that always
 returns the label ``"unknown"``.
 
 ```python
-from vision import Labeler
+from vision.labeler import Labeler
 
 labeler = Labeler()
 labeler.label(None)  # -> "unknown"
 ```
 
-## Cluster store stub
+## Cluster Store
 
 The package provides a :class:`ClusterStore` placeholder that persists
 *exemplar* records to ``data/kb.json`` by default. An exemplar has the
@@ -151,3 +148,7 @@ store.flush()
 # Later
 reloaded = ClusterStore.load("data/kb.json")
 ```
+
+## Documentation
+- [Project Charter](docs/charter.md)
+- [Architecture](docs/architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,28 @@
+# Architecture
+
+## Module Map
+- video: src/vision/webcam.py
+- detect: src/vision/fake_detector.py
+- track: src/vision/tracker.py
+- embed: src/vision/embedder.py
+- match: src/vision/matcher.py
+- label: src/vision/labeler.py
+- kb: src/vision/cluster_store.py
+- ui: overlay in webcam.py
+- ris: (stub placeholder; not implemented)
+- telemetry: (stub placeholder; not implemented)
+
+## Flow
+Webcam → Detect → Track → Embed → Match → Label → (KB add_exemplar) → UI overlay
+
+## Exemplar Schema
+```
+{
+  "label": "unknown",
+  "bbox": [x1, y1, x2, y2],
+  "embedding": [0.0, ... 128 floats ...],
+  "provenance": {"source": "fake", "ts": "<ISO8601>", "note": "stub"}
+}
+```
+
+Default path: `data/kb.json`.

--- a/docs/charter.md
+++ b/docs/charter.md
@@ -1,0 +1,48 @@
+# Charter
+
+## Goal
+- Deliver a minimal vision pipeline to explore detection, tracking, embedding and matching on webcam frames.
+
+## Scope v0
+- Stub implementations for Detector, Tracker, Embedder, Matcher, Labeler and Cluster Store.
+- Command line interface with webcam loop and dry-run mode.
+
+## Scope v1
+- Real detection and tracking models.
+- RIS and telemetry modules with metrics collection.
+- Persistence beyond local JSON exemplars.
+
+## Out of Scope
+- Production-grade models or optimizations.
+- External network calls and RIS integration.
+- Cloud storage or database backends.
+
+## Success Metrics
+- Latency P95 ≤ 800ms @720p.
+- Pipeline initializes in ≤2s.
+- Dry run completes without errors.
+
+## Operating Principles
+- Keep components loosely coupled.
+- Prefer simple, deterministic stubs in M0.
+- Ensure every module has unit tests.
+
+## High-Level Architecture
+- Webcam captures frames.
+- Frames pass through Detector, Tracker, Embedder, Matcher and Labeler.
+- Exemplars stored via Cluster Store; RIS/telemetry deferred.
+
+## Deliverables
+- CLI with webcam command.
+- Stub modules for each stage.
+- Documentation and tests.
+
+## DoD
+- Tests and linters pass.
+- README and examples match behavior.
+- CI pipeline verifies dry-run path.
+
+## Reality Check (M0)
+- Implemented stubs: FakeDetector, Tracker, Embedder, Matcher, Labeler, ClusterStore; wired in webcam loop.
+- Deferred: ris/, telemetry/ modules and metrics collection (planned for M1).
+- Persistence: JSON exemplars with provenance to data/kb.json.


### PR DESCRIPTION
## Summary
- add project charter and architecture docs aligning with M0 reality
- document CLI outputs and success metrics in README; link new docs
- enable markdown lint in CI and ignore data/ path

## Testing
- `PYTHONPATH=src pytest -q`
- `npx markdownlint-cli '**/*.md'` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68afab2f4d908328974fa099c175cb73