### PR TITLE
M0 alignment sweep: add RIS & Telemetry stubs, README sections, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,30 @@ store.flush()
 # Later
 reloaded = ClusterStore.load("data/kb.json")
 ```
+
+## RIS (Reverse Image Search) Stub
+
+A no-network placeholder that always returns an empty result.
+
+```python
+from vision import ReverseImageSearchStub
+
+ris = ReverseImageSearchStub()
+ris.search(object())  # -> []
+```
+
+## Telemetry Stub
+
+An in-memory metrics sink intended to be replaced later.
+
+```python
+from vision import Telemetry
+
+t = Telemetry()
+t.inc("frames")
+t.set_gauge("latency_ms", 12.3)
+```
+
+## Documentation
+- [Project Charter](docs/charter.md)
+- [Architecture](docs/architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,46 @@
+# Architecture
+
+## Module Map
+- **video:** `src/vision/webcam.py`
+- **detect:** `src/vision/fake_detector.py`
+- **track:** `src/vision/tracker.py`
+- **embed:** `src/vision/embedder.py`
+- **match:** `src/vision/matcher.py`
+- **label:** `src/vision/labeler.py`
+- **kb:** `src/vision/cluster_store.py`
+- **ris:** `src/vision/ris.py`
+- **telemetry:** `src/vision/telemetry.py`
+- **ui:** overlay drawing in `webcam.py`
+
+## Pipeline (M0)
+
+Webcam (or Dry Run)
+→ Detect (FakeDetector)
+→ Track (Tracker)
+→ Embed (Embedder)
+→ Match (Matcher)
+→ Label (Labeler)
+→ Cluster Store (add_exemplar with provenance)
+→ UI Overlay (rectangles, ID, label)
+
+## Exemplar Schema (JSON)
+```json
+{
+  "label": "unknown",
+  "bbox": [x1, y1, x2, y2],
+  "embedding": [0.0, "... 128 floats ..."],
+  "provenance": { "source": "fake", "ts": "<ISO8601>", "note": "stub" }
+}
+```
+
+Default path: data/kb.json
+
+Persistence is atomic (temp file replace).
+
+Notes
+
+Dry run exercises the full control flow without requiring OpenCV or network access.
+
+RIS and Telemetry are stubs in M0; real integrations come in M1+.
+
+All modules are unit-tested stubs; CI runs tests and markdown lint.

--- a/docs/charter.md
+++ b/docs/charter.md
@@ -1,0 +1,57 @@
+# Charter
+
+## Goal
+- Deliver a minimal vision pipeline to explore detection, tracking, embedding, matching, labeling, and exemplar persistence on webcam frames (or dry run), with deterministic stubs in M0.
+
+## Scope v0 (M0)
+- Stub implementations for: Detector, Tracker, Embedder, Matcher, Labeler, Cluster Store, RIS (Reverse Image Search), and Telemetry.
+- Command line interface with `vision webcam` and `--dry-run`.
+- JSON persistence of exemplars (label, bbox, embedding, provenance).
+- Unit tests for each stub and CLI dry-run output.
+
+## Scope v1
+- Real detection and tracking models (e.g., YOLO/RT-DETR, DeepSORT/ByteTrack).
+- Replace Embedder with CLIP/OpenCLIP.
+- Real RIS connector + forward search; proper similarity thresholds and smoothing.
+- Telemetry backend integration; evaluation harness; label hysteresis.
+- Configurable thresholds; performance tuning.
+
+## Out of Scope (for now)
+- Training custom models, quantization/acceleration.
+- Multi-camera fusion/SLAM.
+- Cloud DBs (start local only).
+
+## Success Metrics (MVP)
+- Latency: P95 ≤ 800 ms @ 720p (single object).
+- Stability: ≥ 90% identical labels across a 2s window (stationary object).
+- Unknown resolution: ≤ 3.0 s median to resolve to a label (when RIS enabled in later milestones).
+- Reliability: zero crashes in a 20-minute webcam session.
+
+## Operating Principles
+- **Open-set first:** everything unknown until evidence accumulates.
+- **Provenance everywhere:** store sources, timestamps, confidence trails.
+- **Deterministic scaffolding:** swap implementations without churn.
+- **Atomic PRs:** small, testable, reviewable increments.
+- **Privacy & ToS:** persist embeddings, URLs, metadata only.
+
+## High-Level Architecture (modules)
+- `video/` — Frame capture loop (OpenCV) → `src/vision/webcam.py`
+- `detect/` — Object detection (stub → YOLO/RT-DETR) → `src/vision/fake_detector.py`
+- `track/` — Object tracking (stub → DeepSORT/ByteTrack) → `src/vision/tracker.py`
+- `embed/` — Embedding abstraction (stub → CLIP) → `src/vision/embedder.py`
+- `match/` — Similarity search → `src/vision/matcher.py`
+- `label/` — Label choice → `src/vision/labeler.py`
+- `kb/` — Cluster store (label, exemplars, provenance) → `src/vision/cluster_store.py`
+- `ris/` — Reverse image search connector → `src/vision/ris.py`
+- `telemetry/` — Metrics → `src/vision/telemetry.py`
+- `ui/` — AR overlay (OpenCV) → overlay in `webcam.py`
+
+## Deliverables
+- This charter (`docs/charter.md`) and the architecture doc (`docs/architecture.md`).
+- README entries that link to both docs and show exact CLI dry-run outputs.
+- CI runs markdown lint and tests.
+
+## Definition of Done
+- `docs/charter.md` and `docs/architecture.md` present and linked from README.
+- `pytest -q` passes; markdown lint in CI passes.
+- No changes to runtime behavior; all existing tests remain green.

--- a/src/vision/__init__.py
+++ b/src/vision/__init__.py
@@ -4,6 +4,16 @@ from .fake_detector import FakeDetector
 from .embedder import Embedder
 from .matcher import Matcher
 from .labeler import Labeler
+from .ris import ReverseImageSearchStub
+from .telemetry import Telemetry
 
 __version__ = "0.0.1"
-__all__ = ["__version__", "FakeDetector", "Embedder", "Matcher", "Labeler"]
+__all__ = [
+    "__version__",
+    "FakeDetector",
+    "Embedder",
+    "Matcher",
+    "Labeler",
+    "ReverseImageSearchStub",
+    "Telemetry",
+]

--- a/src/vision/ris.py
+++ b/src/vision/ris.py
@@ -1,0 +1,20 @@
+"""
+Reverse Image Search (RIS) stub.
+
+This placeholder mimics a RIS connector. It returns an empty list for any
+query and records the last query payload for debugging/tests.
+"""
+
+from __future__ import annotations
+from typing import Any, Dict, List
+
+class ReverseImageSearchStub:
+    """Stub RIS connector."""
+
+    def __init__(self) -> None:
+        self.last_query: Dict[str, Any] | None = None
+
+    def search(self, image_or_embedding: Any) -> List[Dict[str, Any]]:
+        """Return an empty list of candidates (no network calls)."""
+        self.last_query = {"input": image_or_embedding}
+        return []

--- a/src/vision/telemetry.py
+++ b/src/vision/telemetry.py
@@ -1,0 +1,20 @@
+"""
+Telemetry stub.
+
+Lightweight in-memory counter/gauge store with no external IO. Intended
+for drop-in replacement by a real metrics backend in later milestones.
+"""
+
+from __future__ import annotations
+from typing import Dict
+
+class Telemetry:
+    def __init__(self) -> None:
+        self.counters: Dict[str, int] = {}
+        self.gauges: Dict[str, float] = {}
+
+    def inc(self, name: str, value: int = 1) -> None:
+        self.counters[name] = self.counters.get(name, 0) + value
+
+    def set_gauge(self, name: str, value: float) -> None:
+        self.gauges[name] = float(value)

--- a/tests/test_ris.py
+++ b/tests/test_ris.py
@@ -1,0 +1,7 @@
+from vision import ReverseImageSearchStub
+
+def test_ris_stub_returns_empty_list_and_records_last_query():
+    ris = ReverseImageSearchStub()
+    out = ris.search({"foo": "bar"})
+    assert out == []
+    assert ris.last_query == {"input": {"foo": "bar"}}

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,9 @@
+from vision import Telemetry
+
+def test_telemetry_counters_and_gauges():
+    t = Telemetry()
+    t.inc("frames")
+    t.inc("frames", 2)
+    t.set_gauge("latency_ms", 7.5)
+    assert t.counters["frames"] == 3
+    assert t.gauges["latency_ms"] == 7.5


### PR DESCRIPTION
## Summary
- add ReverseImageSearchStub and Telemetry stubs
- expose new stubs at package level
- document RIS and Telemetry usage in README
- add tests for RIS and Telemetry behavior
- add project charter and architecture docs linked from README

## Testing
- `pytest -q`
- `npx markdownlint README.md docs/charter.md docs/architecture.md` *(fails: 403 Forbidden fetching package)*

------
https://chatgpt.com/codex/tasks/task_e_68b06a175e048328ae5e0c6e282fff25