### PR TITLE
docs: add changelog and CLI smoke tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v0.0.1 - 2025-08-28
+
+- Initial M0 release.
+- Stub modules: FakeDetector, Tracker, Embedder, Matcher, Labeler, ClusterStore, Telemetry, ReverseImageSearchStub, and supporting utilities.
+- CLI commands: `vision --version`, `vision webcam`, `vision webcam --dry-run`, and `vision webcam --use-fake-detector`.
+- Documentation: project charter and architecture overview.
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 A minimal Python package with a command-line interface stub.
 
+## Quickstart
+
+```bash
+pip install -e .
+vision --version
+vision webcam --dry-run
+```
+
 ## Installation
 
 ```bash
@@ -180,6 +188,7 @@ t.set_gauge("latency_ms", 12.3)
 ## Documentation
 - [Project Charter](docs/charter.md)
 - [Architecture](docs/architecture.md)
+- [Changelog](CHANGELOG.md)
 
 ## Contributing
 

--- a/tests/test_cli_outputs.py
+++ b/tests/test_cli_outputs.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PYTHONPATH = os.pathsep.join([str(ROOT / "src"), os.environ.get("PYTHONPATH", "")])
+ENV = {**os.environ, "PYTHONPATH": PYTHONPATH}
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "vision", *args],
+        capture_output=True,
+        text=True,
+        env=ENV,
+        check=True,
+    )
+
+
+def test_version_command_reports_version() -> None:
+    result = run_cli("--version")
+    assert result.stdout.strip() == "Vision 0.0.1"
+
+
+def test_webcam_dry_run_reports_message() -> None:
+    result = run_cli("webcam", "--dry-run")
+    assert result.stdout.strip() == "Dry run: webcam loop skipped"
+
+
+def test_webcam_fake_detector_dry_run_reports_all_steps() -> None:
+    result = run_cli("webcam", "--use-fake-detector", "--dry-run")
+    assert result.stdout.strip() == (
+        "Dry run: fake detector produced 1 boxes, tracker assigned IDs, "
+        "embedder produced 1 embeddings, cluster store prepared 1 exemplar, "
+        "matcher compared embeddings (stub), labeler assigned 'unknown'"
+    )


### PR DESCRIPTION
## Summary
- document initial M0 release in new `CHANGELOG.md`
- add Quickstart and changelog link to README
- strengthen CLI tests by executing the command line

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b078203d3c8328998d0bf0854352b8