### PR TITLE
M1-01 step3: add environment overrides (VISION__) and wire CLI import

### DIFF
--- a/src/vision/cli.py
+++ b/src/vision/cli.py
@@ -6,6 +6,9 @@ import argparse
 from collections.abc import Sequence
 
 from . import __version__, webcam
+from .config import get_config
+
+_ = get_config()
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/vision/config.py
+++ b/src/vision/config.py
@@ -1,0 +1,162 @@
+"""Configuration management for the vision package.
+
+This module exposes a single public function :func:`get_config` which returns
+application configuration as a frozen dataclass hierarchy. Configuration values
+may come from in-code defaults, an optional ``vision.toml`` file, and
+environment variables prefixed with ``VISION__``. The resulting object is
+memoized so subsequent calls return the same instance. A helper
+``_reset_config_cache`` is provided for test suites to clear the memoized
+instance.
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class DetectorConfig:
+    model_path: str = "models/yolov8n.onnx"
+    input_size: int = 640
+
+
+@dataclass(frozen=True)
+class TrackerConfig:
+    type: str = "bytetrack"
+
+
+@dataclass(frozen=True)
+class EmbedderConfig:
+    model: str = "ViT-B-32-openai"
+    batch_size: int = 8
+    device: str = "cpu"
+
+
+@dataclass(frozen=True)
+class MatcherConfig:
+    index_type: str = "faiss-flat"
+    threshold: float = 0.32
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    frame_stride: int = 1
+
+
+@dataclass(frozen=True)
+class LatencyConfig:
+    budget_ms: int = 66
+
+
+@dataclass(frozen=True)
+class Config:
+    detector: DetectorConfig = field(default_factory=DetectorConfig)
+    tracker: TrackerConfig = field(default_factory=TrackerConfig)
+    embedder: EmbedderConfig = field(default_factory=EmbedderConfig)
+    matcher: MatcherConfig = field(default_factory=MatcherConfig)
+    pipeline: PipelineConfig = field(default_factory=PipelineConfig)
+    latency: LatencyConfig = field(default_factory=LatencyConfig)
+
+
+_CONFIG_CACHE: Config | None = None
+
+
+def _deep_merge(base: dict[str, Any], override: Mapping[str, Any]) -> dict[str, Any]:
+    """Recursively merge ``override`` into ``base`` and return the result."""
+
+    result: dict[str, Any] = base.copy()
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, Mapping):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _dict_to_config(data: dict[str, Any]) -> Config:
+    """Convert a nested mapping to a :class:`Config` instance."""
+
+    return Config(
+        detector=DetectorConfig(**data["detector"]),
+        tracker=TrackerConfig(**data["tracker"]),
+        embedder=EmbedderConfig(**data["embedder"]),
+        matcher=MatcherConfig(**data["matcher"]),
+        pipeline=PipelineConfig(**data["pipeline"]),
+        latency=LatencyConfig(**data["latency"]),
+    )
+
+
+def _cast_env_value(value: str) -> Any:
+    """Cast environment variable string to int or float when possible."""
+
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+
+
+def _env_overrides(schema: Mapping[str, Any]) -> dict[str, Any]:
+    """Collect environment variable overrides following ``VISION__`` prefix."""
+
+    prefix = "VISION__"
+    result: dict[str, Any] = {}
+    for raw_key, raw_value in os.environ.items():
+        if not raw_key.startswith(prefix):
+            continue
+        parts = [part.lower() for part in raw_key[len(prefix) :].split("__")]
+        if len(parts) != 2:
+            continue
+        section, field = parts
+        if section not in schema or field not in schema[section]:
+            continue
+        result.setdefault(section, {})[field] = _cast_env_value(raw_value)
+    return result
+
+
+def get_config(toml_path: str | None = None) -> Config:
+    """Return application configuration.
+
+    The configuration is created on first use and cached for the lifetime of the
+    process. Configuration values may be overridden by a ``vision.toml`` file
+    located in the current working directory or supplied via ``toml_path``, and
+    by environment variables prefixed with ``VISION__``. Precedence: defaults <
+    TOML < environment variables (VISION__…). Sections/keys are case-insensitive.
+    The configuration is cached globally; subsequent calls ignore a different
+    ``toml_path`` or env changes unless the cache is reset.
+    """
+
+    global _CONFIG_CACHE
+    if _CONFIG_CACHE is None:
+        cfg_dict = asdict(Config())
+        path = Path(toml_path) if toml_path is not None else Path.cwd() / "vision.toml"
+        if path.is_file():
+            with path.open("rb") as fh:
+                overrides = tomllib.load(fh)
+            cfg_dict = _deep_merge(cfg_dict, overrides)
+        env_cfg = _env_overrides(cfg_dict)
+        if env_cfg:
+            cfg_dict = _deep_merge(cfg_dict, env_cfg)
+        _CONFIG_CACHE = _dict_to_config(cfg_dict)
+    return _CONFIG_CACHE
+
+
+def _reset_config_cache() -> None:
+    """Clear the cached configuration.
+
+    This function is intended for use in test suites to ensure isolation between
+    tests.
+    """
+
+    global _CONFIG_CACHE
+    _CONFIG_CACHE = None
+
+
+__all__ = ["get_config"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,92 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from vision.config import _reset_config_cache, get_config
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    _reset_config_cache()
+
+
+def test_defaults(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg = get_config()
+    assert cfg.detector.model_path == "models/yolov8n.onnx"
+    assert cfg.detector.input_size == 640
+    assert cfg.tracker.type == "bytetrack"
+    assert cfg.embedder.model == "ViT-B-32-openai"
+    assert cfg.embedder.batch_size == 8
+    assert cfg.embedder.device == "cpu"
+    assert cfg.matcher.index_type == "faiss-flat"
+    assert cfg.matcher.threshold == 0.32
+    assert cfg.pipeline.frame_stride == 1
+    assert cfg.latency.budget_ms == 66
+
+
+def test_toml_overrides(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "vision.toml").write_text(
+        """[embedder]\nbatch_size = 16\n\n[latency]\nbudget_ms = 33\n"""
+    )
+    cfg = get_config()
+    assert cfg.embedder.batch_size == 16
+    assert cfg.latency.budget_ms == 33
+
+
+def test_toml_path_argument_overrides(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "other.toml").write_text(
+        """[embedder]\nbatch_size = 12\n\n[latency]\nbudget_ms = 40\n"""
+    )
+    cfg = get_config("other.toml")
+    assert cfg.embedder.batch_size == 12
+    assert cfg.latency.budget_ms == 40
+
+
+def test_env_overrides_precedence(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "vision.toml").write_text(
+        """[embedder]\nbatch_size = 12\n\n[matcher]\nthreshold = 0.25\n"""
+    )
+    monkeypatch.setenv("VISION__EMBEDDER__BATCH_SIZE", "16")
+    monkeypatch.setenv("VISION__MATCHER__THRESHOLD", "0.45")
+    cfg = get_config()
+    assert cfg.embedder.batch_size == 16
+    assert cfg.matcher.threshold == 0.45
+
+
+def test_env_keys_case_insensitive(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("VISION__matcher__THRESHOLD", "0.5")
+    cfg = get_config()
+    assert cfg.matcher.threshold == 0.5
+
+
+def test_env_string_passthrough(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("VISION__EMBEDDER__DEVICE", "cuda")
+    cfg = get_config()
+    assert cfg.embedder.device == "cuda"
+
+
+def test_env_unknown_keys_ignored(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("VISION__FOO__BAR", "123")
+    monkeypatch.setenv("VISION__EMBEDDER__UNKNOWN", "zzz")
+    cfg = get_config()
+    assert cfg.embedder.batch_size == 8
+    assert cfg.embedder.device == "cpu"
+
+
+def test_config_is_cached():
+    first = get_config()
+    second = get_config()
+    assert first is second
+
+
+def test_config_is_immutable():
+    cfg = get_config()
+    with pytest.raises(FrozenInstanceError):
+        cfg.detector.model_path = "other"

--- a/vision.toml
+++ b/vision.toml
@@ -1,0 +1,21 @@
+[detector]
+model_path = "models/yolov8n.onnx"
+input_size = 640
+
+[tracker]
+type = "bytetrack"
+
+[embedder]
+model = "ViT-B-32-openai"
+batch_size = 8
+device = "cpu"
+
+[matcher]
+index_type = "faiss-flat"
+threshold = 0.32
+
+[pipeline]
+frame_stride = 1
+
+[latency]
+budget_ms = 66


### PR DESCRIPTION
## Summary
- extend config loader with environment variable overrides that supersede defaults and TOML
- load config at CLI startup to ensure configuration is instantiated
- expand test suite for environment precedence, case-insensitive keys, string passthrough, and unknown key handling

## Testing
- `ruff check .`
- `mypy src/vision tests`
- `pytest -q`
- `make verify` *(fails: npm error code E403 403 Forbidden - GET https://registry.npmjs.org/markdownlint-cli2)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dae29f508328a44def3893d5e8d1