### PR TITLE
chore(license): add copyright lines alongside SPDX headers

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 [run]
 branch = True
 source = vision

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 root = true
 
 [*]

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 * text=auto
 
 *.py   text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 name: ci
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 config:
   default: true
   MD013: false

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 registry=https://registry.npmjs.org/
 fetch-retries=3
 fetch-retry-factor=2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.4

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 # Default owner/reviewer for everything in this repo
 * @matthewtpapa
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 include LICENSE
 include NOTICE

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 .RECIPEPREFIX := >
 .PHONY: setup test test-cov cov-html lint fmt format type mdlint mdfix verify help
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 import sys
 from pathlib import Path
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 [mypy]
 python_version = 3.11
 ignore_missing_imports = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 [pytest]
 addopts = -q --maxfail=1 --disable-warnings
 testpaths =

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 setuptools>=61,<70
 pytest~=8.3
 pytest-cov~=4.1

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 line-length = 100
 target-version = "py311"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 [options]
 package_dir =
     =src

--- a/src/vision/__init__.py
+++ b/src/vision/__init__.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Top-level package for vision."""
 
 from .embedder import Embedder

--- a/src/vision/__main__.py
+++ b/src/vision/__main__.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from .cli import main
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/vision/associations.py
+++ b/src/vision/associations.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Typed associations between tracks and embeddings."""
 
 from __future__ import annotations

--- a/src/vision/cli.py
+++ b/src/vision/cli.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Command-line interface for vision."""
 
 from __future__ import annotations

--- a/src/vision/cluster_store.py
+++ b/src/vision/cluster_store.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Cluster store stub with JSON persistence."""
 
 from __future__ import annotations

--- a/src/vision/config.py
+++ b/src/vision/config.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Configuration management for the vision package.
 
 This module exposes a single public function :func:`get_config` which returns

--- a/src/vision/detect_adapter.py
+++ b/src/vision/detect_adapter.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Detection adapter interfaces and fakes."""
 
 from __future__ import annotations

--- a/src/vision/detect_yolo_adapter.py
+++ b/src/vision/detect_yolo_adapter.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """YOLO-like detection adapter."""
 
 from __future__ import annotations

--- a/src/vision/embedder.py
+++ b/src/vision/embedder.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Feature embedder stub."""
 
 from __future__ import annotations

--- a/src/vision/embedder_adapter.py
+++ b/src/vision/embedder_adapter.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Embedder interfaces and CLIP-like adapter."""
 
 from __future__ import annotations

--- a/src/vision/embedding_types.py
+++ b/src/vision/embedding_types.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Embedding data contracts and helpers."""
 
 from __future__ import annotations

--- a/src/vision/eval_reporting.py
+++ b/src/vision/eval_reporting.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 from statistics import fmean

--- a/src/vision/factory.py
+++ b/src/vision/factory.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Factories for constructing detector and tracker implementations."""
 
 from __future__ import annotations

--- a/src/vision/fake_detector.py
+++ b/src/vision/fake_detector.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Fake object detector stub."""
 
 from __future__ import annotations

--- a/src/vision/index_utils.py
+++ b/src/vision/index_utils.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Utilities for working with matcher indices."""
 
 from __future__ import annotations

--- a/src/vision/labeler.py
+++ b/src/vision/labeler.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Labeler stub."""
 
 from __future__ import annotations

--- a/src/vision/matcher/__init__.py
+++ b/src/vision/matcher/__init__.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Embedding matcher stub."""
 
 from __future__ import annotations

--- a/src/vision/matcher/factory.py
+++ b/src/vision/matcher/factory.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Factory for building the best available matcher backend."""
 
 from __future__ import annotations

--- a/src/vision/matcher/faiss_backend.py
+++ b/src/vision/matcher/faiss_backend.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """FAISS matcher backend implementing :class:`MatcherProtocol`."""
 
 from __future__ import annotations

--- a/src/vision/matcher/matcher_protocol.py
+++ b/src/vision/matcher/matcher_protocol.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Protocol definitions for embedding matchers.
 
 Vectors are expected to be L2-normalised ``float32`` arrays and similarity is

--- a/src/vision/matcher/py_fallback.py
+++ b/src/vision/matcher/py_fallback.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """NumPy matcher backend implementing :class:`MatcherProtocol`."""
 
 from __future__ import annotations

--- a/src/vision/matcher/types.py
+++ b/src/vision/matcher/types.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 from typing import TypedDict

--- a/src/vision/pipeline_detect_track.py
+++ b/src/vision/pipeline_detect_track.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Simple detection-to-tracking pipeline."""
 
 from __future__ import annotations

--- a/src/vision/pipeline_detect_track_embed.py
+++ b/src/vision/pipeline_detect_track_embed.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Detection → tracking → embedding pipeline."""
 
 from __future__ import annotations

--- a/src/vision/ris.py
+++ b/src/vision/ris.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """
 Reverse Image Search (RIS) stub.
 

--- a/src/vision/telemetry.py
+++ b/src/vision/telemetry.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Timing helpers for lightweight telemetry.
 
 This module provides a minimal in-memory aggregator for stage timings along

--- a/src/vision/track_adapter.py
+++ b/src/vision/track_adapter.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Tracking adapter interfaces and simple implementations."""
 
 from __future__ import annotations

--- a/src/vision/track_bytetrack_adapter.py
+++ b/src/vision/track_bytetrack_adapter.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """ByteTrack-like tracker adapter."""
 
 from __future__ import annotations

--- a/src/vision/tracker.py
+++ b/src/vision/tracker.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Simple object tracker stub."""
 
 from __future__ import annotations

--- a/src/vision/types.py
+++ b/src/vision/types.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Typed data contracts for detection and tracking.
 
 This module defines lightweight immutable dataclasses that model the

--- a/src/vision/webcam.py
+++ b/src/vision/webcam.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 """Webcam support utilities."""
 
 from __future__ import annotations

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 from vision import __version__

--- a/tests/test_cli_outputs.py
+++ b/tests/test_cli_outputs.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 import os

--- a/tests/test_cluster_store.py
+++ b/tests/test_cluster_store.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 import json
 from pathlib import Path
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from dataclasses import FrozenInstanceError
 
 import pytest

--- a/tests/test_detect_track_adapters.py
+++ b/tests/test_detect_track_adapters.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 import dataclasses

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from vision import Embedder
 
 

--- a/tests/test_embedder_adapter.py
+++ b/tests/test_embedder_adapter.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from dataclasses import FrozenInstanceError
 
 import pytest

--- a/tests/test_fake_detector.py
+++ b/tests/test_fake_detector.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from vision.fake_detector import FakeDetector
 
 

--- a/tests/test_index_incremental.py
+++ b/tests/test_index_incremental.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 import pytest

--- a/tests/test_index_utils.py
+++ b/tests/test_index_utils.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 import pytest

--- a/tests/test_labeler.py
+++ b/tests/test_labeler.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from vision import Labeler
 
 

--- a/tests/test_match_unknown_policy.py
+++ b/tests/test_match_unknown_policy.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 import pytest
 
 pytest.importorskip("numpy")

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from vision.matcher import Matcher
 
 

--- a/tests/test_matcher_factory.py
+++ b/tests/test_matcher_factory.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 import builtins

--- a/tests/test_matcher_faiss_parity.py
+++ b/tests/test_matcher_faiss_parity.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 import pytest

--- a/tests/test_matcher_numpy_backend.py
+++ b/tests/test_matcher_numpy_backend.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 from math import sqrt

--- a/tests/test_pipeline_and_factory.py
+++ b/tests/test_pipeline_and_factory.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 import pytest

--- a/tests/test_pipeline_backend_introspection.py
+++ b/tests/test_pipeline_backend_introspection.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 import json

--- a/tests/test_pipeline_detect_track_embed.py
+++ b/tests/test_pipeline_detect_track_embed.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 import pytest

--- a/tests/test_pipeline_match_schema.py
+++ b/tests/test_pipeline_match_schema.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from __future__ import annotations
 
 import pytest

--- a/tests/test_ris.py
+++ b/tests/test_ris.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from vision import ReverseImageSearchStub
 
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 import pytest
 
 import vision.telemetry as telemetry

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from vision.tracker import Tracker
 
 

--- a/tests/test_yolo_bytetrack_adapters.py
+++ b/tests/test_yolo_bytetrack_adapters.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 from vision.detect_yolo_adapter import YoloLikeDetector
 from vision.track_bytetrack_adapter import ByteTrackLikeTracker
 from vision.types import Detection

--- a/vision.toml
+++ b/vision.toml
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025 The Vision Authors
 [detector]
 model_path = "models/yolov8n.onnx"
 input_size = 640


### PR DESCRIPTION
## Summary
- add missing copyright lines next to SPDX headers across source, test, and config files

## Testing
- `make fmt`
- `make type`
- `make test`
- `make verify`


------
https://chatgpt.com/codex/tasks/task_e_68b393f0e9bc83288ba10bd18c47a116