### PR TITLE
Charter: add Milestone M1.1 (scope, gates, cross-links)

### DIFF
--- a/docs/charter.md
+++ b/docs/charter.md
@@ -39,3 +39,28 @@ Deliver a real-time, open-set recognition SDK: detect, track, embed, and match o
 - **Charter (this doc)** → sets vision, roadmap, and themes. Evolves slowly (reviewed at major milestones)
 - **Specs (per milestone)** → exact contracts, telemetry schemas, CI gates. Evolve quickly, live close to code
 - Charter answers "what and why"; Specs answer "how and with what guarantees"
+
+## Milestone M1.1 — SDK Reality & Latency SLO (Investor-Facing)
+
+**Goal (0.1.x):** Ship a latency-bounded open-set SDK with a minimal façade (`add_exemplar`, `query_frame`), a canonical CLI (`latvision`), and a one-command reproducible benchmark. Public positioning: *predictable, measurable, embeddable*.
+
+### What ships in M1.1
+
+- Python façade (importable in 5 lines), canonical CLI rename, and “hello → eval → plot” demo path.
+- Frozen result schema v0.1; CI guard against breaking changes.
+- Windowed p95 controller (stride/skip only), with sustained-run SLO reporting.
+- Reproducible fixture + summary/plot scripts; artifacts published on RC tags.
+
+### Acceptance gates (all must be green)
+
+- **Gate A — SDK Reality & Platform Matrix.** `pip install latency-vision` works on macOS/Windows/Linux; `from latency_vision import add_exemplar, query_frame` imports succeed; README 5-liner returns a `MatchResult` that matches **[docs/schema.md](../schema.md)**. CI matrix: Python 3.10/3.11/3.12 × macOS (x86_64/arm64), Windows (x86_64), Linux (manylinux2014 x86_64).
+- **Gate B — Latency & SLO.** On reference CPUs, windowed run (≥2k frames; warm-up excluded) yields `p95 ≤ 33 ms`, `p99 ≤ 66 ms`, `FPS ≥ 25`. Sustained 10-minute run: ≥99.5% frames within 33 ms. Cold-start ≤ 1.0 s, index bootstrap @ N=1k ≤ 50 ms.
+- **Gate C — Reproducibility (1 command).** `make bench` builds fixture, runs eval with fixed seed, emits `out/metrics.json` + `out/stage_times.csv`, and prints a summary. Artifacts record `sdk_version`, `git_commit`, `hardware_id`, `fixture_hash`.
+- **Gate D — Installability & Hello World.** Clean macOS/Windows/Linux installs succeed; a Windows user can run the README 5-liner (NumPy backend fallback) and share `MatchResult` JSON.
+
+### Cross-references
+
+- M1.1 detailed spec & gates: **[docs/specs/m1.1.md](../specs/m1.1.md)**
+- Result schema v0.1 (frozen): **[docs/schema.md](../schema.md)**
+- Controller & process model: **[docs/latency.md](../latency.md)**
+- Benchmark methodology: **[docs/benchmarks.md](../benchmarks.md)**


### PR DESCRIPTION
## Summary
- add M1.1 milestone section to the charter with goal, deliverables and acceptance gates A–D
- link to upcoming M1.1 spec, schema v0.1, latency, and benchmarks docs

## Testing
- `npx markdownlint-cli2 docs/charter.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4b2bc63a08328b12e1ef4ca568910