### PR TITLE
Spec: add docs/specs/m1.1.md (Gates A–D, matrix, SLOs, repro)

### DIFF
--- a/docs/specs/m1.1.md
+++ b/docs/specs/m1.1.md
@@ -1,0 +1,175 @@
+# Milestone M1.1 Spec — SDK Reality & Latency SLO
+
+**Goal:** Ship a latency-bounded open-set SDK with a 5-line façade, canonical CLI, and a one-command reproducible bench. Positioning: *predictable, measurable, embeddable.*
+
+---
+
+## Gate A — SDK Reality & Platform Matrix (must be green)
+
+### A1. Package & API reality
+
+- **PyPI name:** `latency-vision`
+- **Import module:** `latency_vision`
+- **CLI:** `latvision` (best-effort alias `vision` allowed)
+- `pip install latency-vision` on clean machines must succeed.
+- `from latency_vision import add_exemplar, query_frame` must import.
+- README 5-liner returns a JSON object matching **[../schema.md](../schema.md)** (v0.1 frozen).
+
+### A2. Platform / Python matrix (CI must pass all cells)
+
+- **Python:** 3.10, 3.11, 3.12
+- **OS/Arch:**
+  - macOS: x86_64, arm64 (universal2 wheels acceptable)
+  - Windows: x86_64
+  - Linux: manylinux2014 x86_64
+- **Policy:** Wheels build/install/import for every cell. Any failure = Gate A **red**.
+
+### A3. Backends & extras
+
+- Default backend: NumPy.
+- Speed extras: `latency-vision[speed]` installs FAISS CPU on macOS/Linux.
+- Windows may fall back to NumPy by policy (documented in README).
+
+---
+
+## Gate B — Latency & SLOs (must be green)
+
+### B1. Reference boxes (either class acceptable; both preferred)
+
+- Apple M1 / M3 mobile, or Intel i7-1165G7 / modern Ryzen 7 mobile.
+
+### B2. Windowed run (≥ 2,000 frames; **warm-up 100 excluded**)
+
+- Report: `p50`, `p95`, `p99`, `FPS`.
+- **Targets:** `p95 ≤ 33 ms`, `p99 ≤ 66 ms`, `FPS ≥ 25`.
+
+### B3. Sustained SLO (10 minutes)
+
+- ≥ **99.5%** frames within **33 ms** (Error Budget ≤ 0.5%).
+- Controller visibly holds budget via stride/skip; time-series published.
+
+### B4. Cold-start & bootstrap
+
+- **Cold-start:** import → first `MatchResult` ≤ **1.0 s**.
+- **Bootstrap:** index load @ **N=1k** ≤ **50 ms**.
+
+### B5. Unknown-rate guardrail (fixture-bound)
+
+- On the reference fixture, unknown-rate ∈ **[low, high]** band from the fixture manifest.
+- CLI fails Gate B if out of band.
+
+---
+
+## Gate C — Reproducibility (1 command; must be green)
+
+### C1. One-command bench
+
+- `make bench`:
+  1) builds fixture with `scripts/build_fixture.py --seed 42`;
+  2) runs `latvision eval --frames 2000 --seed 42 --kb 1000 --budget-ms 33 --report out/metrics.json --stages out/stage_times.csv`;
+  3) prints summary via `scripts/print_summary.py out/metrics.json`.
+
+### C2. Artifacts (must include)
+
+- `sdk_version`, `git_commit`, `hardware_id`, `fixture_hash`.
+- `out/metrics.json` (schema v0.1) and `out/stage_times.csv` (deterministic per-stage summary).
+
+### C3. Plotting
+
+- `make plot` calls `scripts/plot_latency.py` to emit `out/latency.png` (time-series p50/p95/p99/FPS).
+- Attached to RC tags.
+
+---
+
+## Gate D — Installability & Hello World (must be green)
+
+### D1. Clean installs
+
+- Fresh macOS, Windows, Ubuntu runners install successfully.
+- NumPy fallback path must operate on all platforms; FAISS via extras on macOS/Linux.
+
+### D2. Hello flow (Windows included)
+
+- External user on Windows runs README 5-liner (NumPy backend) in ≤ 5 minutes.
+- Produces `MatchResult` JSON matching **[../schema.md](../schema.md)**.
+
+### D3. CI publishing
+
+- On every RC tag, CI uploads `metrics.json`, `stage_times.csv`, `latency.png` as artifacts.
+
+---
+
+## Fixture (frozen methodology)
+
+**Name:** `COCO-subset-openset-2k`  
+**Builder:** `scripts/build_fixture.py` (deterministic)
+
+- Uses a checked-in list of COCO 2017 val IDs.
+- Fixed crops/resolution; deterministic augments with `--seed 42`.
+- Emits manifest with: `ids`, transforms, `unknown_band`, `fixture_hash`.
+
+> If redistribution is restricted, also provide a synthetic generator that produces the same manifest shape and guardrail behavior.
+
+---
+
+## Schema stability (v0.1) & CI guard
+
+- `docs/schema.md` v0.1 is **frozen** for 0.1.x.
+- CI loads golden `MatchResult` JSON; any field removal/rename = **fail**.
+
+**MatchResult (v0.1) fields** *(see schema for full definitions)*
+
+- `label: string | "unknown"`
+- `confidence: float` (top-1 cosine in [-1,1], uncalibrated)
+- `neighbors: list[{label, score}]`
+- `backend: "faiss" | "numpy"`
+- `stride: int`
+- `budget_hit: bool`
+- `bbox: [x1,y1,x2,y2] | null`
+- `timestamp_ms: int` (optional)
+- `sdk_version: string`
+
+---
+
+## Process / thread model (v0.1)
+
+- Single-process, single-stream.
+- Reads are thread-safe; `add_exemplar` writes are serialized.
+- No degrade-embedding policy; latency control is stride/skip only.
+- See **[../latency.md](../latency.md)** for controller details & stress narrative.
+
+---
+
+## Memory & cap behavior
+
+- Publish RAM @ N=1k (MB) in benchmarks.
+- At cap in v0.1: reject new exemplars (no eviction). Document in README FAQ and **[../benchmarks.md](../benchmarks.md)**.
+
+---
+
+## Measurement notes (benchmarks hygiene)
+
+- Clock: `time.monotonic_ns()` only.
+- Percentiles: NumPy with `"linear"` interpolation (document version).
+- Warm-up frames excluded explicitly.
+- GC/BLAS notes and CPU feature detection recorded in **[../benchmarks.md](../benchmarks.md)**.
+- SIMD banner printed by `latvision hello` (AVX2/NEON/no-SIMD), wheel flavor noted.
+
+---
+
+## Cross-references
+
+- Charter context: **[../charter.md](../charter.md)**
+- Result schema (frozen): **[../schema.md](../schema.md)**
+- Latency controller & process model: **[../latency.md](../latency.md)**
+- Benchmark methodology: **[../benchmarks.md](../benchmarks.md)**
+
+---
+
+Acceptance checklist
+
+- docs/specs/m1.1.md created with Gates A–D and all acceptance bullets.
+- Matrix, SLOs (p50/p95/p99, FPS), cold-start, bootstrap, unknown-band documented.
+- Repro steps (make bench, make plot) and artifact requirements captured.
+- Cross-links to charter.md, schema.md, latency.md, benchmarks.md included.
+- File passes markdownlint locally; CI advisory is fine.


### PR DESCRIPTION
## Summary
- add investor-grade M1.1 spec capturing Gates A–D
- spell out platform/Python matrix, latency SLOs, and cold-start/bootstrap targets
- document one-command bench with artifacts/plots and installability + hello flow

## Testing
- `npm run mdlint docs/specs/m1.1.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4b56814788328ba5882c5ba3484d4