### PR TITLE
docs: add third-party attributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,10 @@ When changing runtime behavior or schemas, update the relevant Spec in the same 
 - CI enforces markdownlint via a pinned GitHub Action.
 - Optional local run: `npm ci && npx markdownlint-cli2 "**/*.md"` (or install it globally).
 
+### Docs hygiene
+
+- Update `THIRD_PARTY.md` whenever docs or examples add a new external reference.
+
 ### Local Markdown lint (pinned toolchain)
 
 ```bash

--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,4 @@
 vision
 Copyright (c) 2025 The Vision Authors
 Licensed under the Apache License, Version 2.0.
+See THIRD_PARTY.md for attributions.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ print(result["label"], result.get("confidence"), result.get("is_unknown"))
 - Result Schema v0.1 (frozen): **[docs/schema.md](docs/schema.md)**
 - Latency & process model: **[docs/latency.md](docs/latency.md)**
 - Benchmarks methodology: **[docs/benchmarks.md](docs/benchmarks.md)**
+- Third-party attributions: **[THIRD_PARTY.md](THIRD_PARTY.md)**
 
 ## Demo path (coming in M1.1)
 

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -1,0 +1,70 @@
+# Third-party Attributions
+
+This project acknowledges the following third-party software, models, and datasets.
+Items may be *referenced* by documentation or examples without being bundled.
+
+> Nothing in this document changes the licenses of the upstream projects.
+> Please consult the upstream links for the full terms.
+
+---
+
+## Libraries
+
+- **FAISS (Facebook AI Similarity Search)**  
+  License: MIT  
+  Source: <https://github.com/facebookresearch/faiss>
+
+- **NumPy**  
+  License: BSD-3-Clause  
+  Source: <https://github.com/numpy/numpy>
+
+- **Pillow (PIL fork)**  
+  License: HPND (Historical Permission Notice and Disclaimer) + exceptions  
+  Source: <https://github.com/python-pillow/Pillow>  
+  Notes: See repo for bundled library notices.
+
+---
+
+## Models / Algorithms (referenced)
+
+- **CLIP** (Contrastive Language-Image Pretraining)  
+  License: MIT (code) / see repo for weights terms  
+  Source: <https://github.com/openai/CLIP>
+
+- **ByteTrack** (multi-object tracking)  
+  License: MIT  
+  Source: <https://github.com/ifzhang/ByteTrack>
+
+- **YOLO family** (object detection; various repos)  
+  License: varies by implementation (e.g., AGPL-3.0 for Ultralytics YOLOv5)  
+  Sources: <https://github.com/ultralytics/yolov5> , <https://github.com/ultralytics/ultralytics>
+
+> Our current code includes *adapters/stubs* that are compatible with these
+> algorithms; we do not redistribute their weights.
+
+---
+
+## Datasets (referenced)
+
+- **COCO 2017** (Common Objects in Context)  
+  License: CC BY 4.0  
+  Source: <https://cocodataset.org/#home> , <https://github.com/cocodataset/cocoapi>  
+  Notes: Redistribution of images may be restricted; our fixture builder  
+  is designed to operate from user-provided downloads.
+
+---
+
+## Tooling / Docs
+
+- **markdownlint-cli2**  
+  License: MIT  
+  Source: <https://github.com/DavidAnson/markdownlint-cli2>
+
+---
+
+### How to update this file
+
+1. Add new entries when docs, examples, or code reference an external work.
+2. Include: *name, license, source URL, and any relevant notes*.
+3. If we start distributing binaries or weights, add the required license
+   texts to `NOTICE` as appropriate.


### PR DESCRIPTION
## Summary
- document third-party libraries, models, datasets, and tooling
- link attributions from README
- remind contributors to update third-party attributions
- mention attributions in NOTICE

## Testing
- `npx markdownlint-cli2 THIRD_PARTY.md README.md CONTRIBUTING.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4bcd7ec84832895540226885d29d2