### PR TITLE
Bench/plot hardening — preflights, headless plotting, filename alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,7 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# Local benchmark artifacts
+/data/fixture/
+/out/

--- a/Makefile
+++ b/Makefile
@@ -106,3 +106,16 @@ clean:
 
 release: clean build check
 >@echo "✅ Artifacts ready in ./dist"
+
+.PHONY: bench plot
+
+bench:
+>python -c "import PIL" 2>/dev/null || { echo 'Missing dependency: pillow'; exit 3; }
+>python -c "import numpy" 2>/dev/null || { echo 'Missing dependency: numpy'; exit 3; }
+>python scripts/build_fixture.py --seed 42 --out data/fixture
+>python -m vision eval --input data/fixture --output out --warmup 100
+>python scripts/print_summary.py out/metrics.json
+
+plot:
+>python -c "import matplotlib" 2>/dev/null || { echo 'Missing dependency: matplotlib'; exit 3; }
+>MPLBACKEND=Agg python scripts/plot_latency.py --metrics out/metrics.json --out out/latency.png

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ print(result["label"], result.get("confidence"), result.get("is_unknown"))
 pip install latency-vision
 latvision hello
 latvision eval --frames 2000 --seed 42 --kb 1000 --budget-ms 33 \
-  --report out/metrics.json --stages out/stage_times.csv
+  --report out/metrics.json --stages out/stage_timings.csv
 make plot
 ```
 
@@ -124,7 +124,7 @@ Exit codes:
 The evaluator can adaptively skip frames to stay within the latency budget; see the **[Eval Guide](docs/eval.md)** and **[Latency Guide](docs/latency.md)** for controller details.
 
 See [Benchmarks](docs/benchmarks.md)
-for measurement details and artifact fields.
+for measurement details and artifact fields. Try `make bench` then `make plot` to generate local metrics and a latency PNG. See docs/benchmarks.md for details.
 
 Example with environment overrides:
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -45,7 +45,7 @@ Related docs:
 - **Repro fields** (required for RCs):
   - `git_commit`, `hardware_id` (CPU model / SIMD flags / OS), `fixture_hash`
 
-**Stage summary (stage_times.csv):**
+**Stage summary (stage_timings.csv):**
 
 - Columns: `stage,total_ms,mean_ms,count`
 - Only **processed** frames contribute to `count`.
@@ -93,7 +93,7 @@ the manifest band `[low, high]`. CLI fails the bench if out of band.
 bench:
     python scripts/build_fixture.py --seed 42 --out data/fixture
     latvision eval --frames 2000 --kb 1000 --budget-ms 33 --seed 42 \
-      --report out/metrics.json --stages out/stage_times.csv
+      --report out/metrics.json --stages out/stage_timings.csv
     python scripts/print_summary.py out/metrics.json
 
 plot:
@@ -105,7 +105,7 @@ Attach to every RC tag:
 
 out/metrics.json
 
-out/stage_times.csv
+out/stage_timings.csv
 
 out/latency.png (time-series)
 

--- a/docs/charter.md
+++ b/docs/charter.md
@@ -55,7 +55,7 @@ Deliver a real-time, open-set recognition SDK: detect, track, embed, and match o
 
 - **Gate A — SDK Reality & Platform Matrix.** `pip install latency-vision` works on macOS/Windows/Linux; `from latency_vision import add_exemplar, query_frame` imports succeed; README 5-liner returns a `MatchResult` that matches **[docs/schema.md](../schema.md)**. CI matrix: Python 3.10/3.11/3.12 × macOS (x86_64/arm64), Windows (x86_64), Linux (manylinux2014 x86_64).
 - **Gate B — Latency & SLO.** On reference CPUs, windowed run (≥2k frames; warm-up excluded) yields `p95 ≤ 33 ms`, `p99 ≤ 66 ms`, `FPS ≥ 25`. Sustained 10-minute run: ≥99.5% frames within 33 ms. Cold-start ≤ 1.0 s, index bootstrap @ N=1k ≤ 50 ms.
-- **Gate C — Reproducibility (1 command).** `make bench` builds fixture, runs eval with fixed seed, emits `out/metrics.json` + `out/stage_times.csv`, and prints a summary. Artifacts record `sdk_version`, `git_commit`, `hardware_id`, `fixture_hash`.
+- **Gate C — Reproducibility (1 command).** `make bench` builds fixture, runs eval with fixed seed, emits `out/metrics.json` + `out/stage_timings.csv`, and prints a summary. Artifacts record `sdk_version`, `git_commit`, `hardware_id`, `fixture_hash`.
 - **Gate D — Installability & Hello World.** Clean macOS/Windows/Linux installs succeed; a Windows user can run the README 5-liner (NumPy backend fallback) and share `MatchResult` JSON.
 
 ### Cross-references

--- a/docs/specs/m1.1.md
+++ b/docs/specs/m1.1.md
@@ -66,13 +66,13 @@
 
 - `make bench`:
   1) builds fixture with `scripts/build_fixture.py --seed 42`;
-  2) runs `latvision eval --frames 2000 --seed 42 --kb 1000 --budget-ms 33 --report out/metrics.json --stages out/stage_times.csv`;
+  2) runs `latvision eval --frames 2000 --seed 42 --kb 1000 --budget-ms 33 --report out/metrics.json --stages out/stage_timings.csv`;
   3) prints summary via `scripts/print_summary.py out/metrics.json`.
 
 ### C2. Artifacts (must include)
 
 - `sdk_version`, `git_commit`, `hardware_id`, `fixture_hash`.
-- `out/metrics.json` (schema v0.1) and `out/stage_times.csv` (deterministic per-stage summary).
+- `out/metrics.json` (schema v0.1) and `out/stage_timings.csv` (deterministic per-stage summary).
 
 ### C3. Plotting
 
@@ -95,7 +95,7 @@
 
 ### D3. CI publishing
 
-- On every RC tag, CI uploads `metrics.json`, `stage_times.csv`, `latency.png` as artifacts.
+- On every RC tag, CI uploads `metrics.json`, `stage_timings.csv`, `latency.png` as artifacts.
 
 ---
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,6 @@ pytest~=8.3
 pytest-cov~=4.1
 mypy~=1.10
 ruff~=0.4
+matplotlib~=3.8
+numpy>=1.26,<2
+pillow>=10,<11

--- a/scripts/build_fixture.py
+++ b/scripts/build_fixture.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+import argparse
+import pathlib
+import random
+
+from PIL import Image, ImageDraw
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--out", type=pathlib.Path, required=True)
+    args = ap.parse_args()
+
+    random.seed(args.seed)
+    args.out.mkdir(parents=True, exist_ok=True)
+
+    for i in range(2000):
+        img = Image.new(
+            "RGB",
+            (96, 96),
+            ((i * 7) % 255, (i * 13) % 255, (i * 29) % 255),
+        )
+        d = ImageDraw.Draw(img)
+        x = 8 + (i % 24)
+        d.rectangle((x, 10, x + 48, 58), outline=(255, 255, 255))
+        img.save(args.out / f"{i:06d}.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_latency.py
+++ b/scripts/plot_latency.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+import argparse
+import json
+
+import matplotlib.pyplot as plt
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--metrics", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    with open(args.metrics, encoding="utf-8") as f:
+        m = json.load(f)
+
+    stats = {k: m.get(k) for k in ("p50", "p95", "p99")}
+    items = [(k, v) for k, v in stats.items() if isinstance(v, (int | float))]
+    plt.figure()
+    if items:
+        labels, values = zip(*items)
+        plt.bar(labels, values)
+        plt.title("Latency percentiles (ms)")
+        plt.ylabel("ms")
+    else:
+        txt = "\n".join([f"{k}: {stats.get(k, 'N/A')}" for k in ("p50", "p95", "p99")])
+        plt.text(0.1, 0.5, txt, fontsize=12)
+        plt.axis("off")
+    plt.tight_layout()
+    plt.savefig(args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/print_summary.py
+++ b/scripts/print_summary.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+import argparse
+import json
+
+
+def _get(d, keys, default="N/A"):
+    cur = d
+    for k in keys:
+        if not isinstance(cur, dict) or k not in cur:
+            return default
+        cur = cur[k]
+    return cur
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("metrics", help="Path to metrics.json")
+    args = ap.parse_args()
+
+    with open(args.metrics, encoding="utf-8") as f:
+        m = json.load(f)
+    c = m.get("controller", {})
+
+    rows = [
+        ("fps", m.get("fps", "N/A")),
+        ("p50 (ms)", m.get("p50", "N/A")),
+        ("p95 (ms)", m.get("p95", "N/A")),
+        ("p99 (ms)", m.get("p99", "N/A")),
+        (
+            "frames processed",
+            f"{_get(c, ['frames_processed'])}/{_get(c, ['frames_total'])}",
+        ),
+        (
+            "stride start→end",
+            f"{_get(c, ['start_stride'])}→{_get(c, ['end_stride'])}",
+        ),
+        ("backend", m.get("backend_selected", "N/A")),
+        ("kb_size", m.get("kb_size", "N/A")),
+    ]
+    w = max(len(k) for k, _ in rows) + 2
+    for k, v in rows:
+        print(f"{k:<{w}}{v}")
+
+    fps = m.get("fps")
+    p95 = m.get("p95")
+    verdict = "N/A"
+    if isinstance(fps, (int | float)) and isinstance(p95, (int | float)):
+        verdict = "PASS" if (p95 <= 33 and fps >= 25) else "FAIL"
+    print(f"\nVERDICT: {verdict}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add dependency checks and headless backend to `bench`/`plot` targets
- record `numpy` and `pillow` as dev dependencies and ignore generated bench artifacts
- align docs to `stage_timings.csv`

## Testing
- `pip install numpy pillow matplotlib` *(fails: Could not find a version that satisfies the requirement numpy)*
- `ruff check scripts/build_fixture.py scripts/print_summary.py scripts/plot_latency.py`
- `pytest`
- `make bench` *(fails: Missing dependency: pillow)*
- `make plot` *(fails: Missing dependency: matplotlib)*
- `npx markdownlint-cli2 docs/benchmarks.md README.md docs/specs/m1.1.md docs/charter.md` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c088b3c883288254457fea5a0974