### PR TITLE
Next (PR-E) — RC drill + docs links sanity

### DIFF
--- a/.github/workflows/rc-artifacts.yml
+++ b/.github/workflows/rc-artifacts.yml
@@ -32,6 +32,25 @@ jobs:
           latvision eval --input bench/fixture --output bench/out --warmup 0 --unknown-rate-band 0.0,1.0 || true
           python scripts/print_summary.py --metrics bench/out/metrics.json || true
 
+      - name: Check metrics.json shape (best effort)
+        run: |
+          if [ -f bench/out/metrics.json ]; then
+            python - <<'PY'
+import json
+path = "bench/out/metrics.json"
+required = ["sdk_version", "p95_ms", "slo_budget_ms", "slo_within_budget_pct"]
+try:
+    data = json.load(open(path))
+    missing = [k for k in required if k not in data]
+    if missing:
+        print(f"::warning::metrics.json missing keys: {', '.join(missing)}")
+except Exception as e:
+    print(f"::warning::error parsing metrics.json: {e}")
+PY
+          else
+            echo "::warning::bench/out/metrics.json missing"
+          fi
+
       - name: Plot latency (best effort)
         run: |
           python scripts/plot_latency.py --input bench/out/stage_timings.csv || true

--- a/Makefile
+++ b/Makefile
@@ -140,3 +140,7 @@ clean:
 
 release: clean build check
 >@echo "✅ Artifacts ready in ./dist"
+
+release-rc:
+>@echo "git tag -a v0.1.0-rc.2 -m \"M1.1 RC drill\""
+>@echo "git push origin v0.1.0-rc.2"

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -1,6 +1,7 @@
 # Latency Controller & Process Model (v0.1)
 
 > Latest RC artifacts: [metrics.json](https://github.com/latvision/vision/releases/latest/download/metrics.json) · [stage_timings.csv](https://github.com/latvision/vision/releases/latest/download/stage_timings.csv) · [latency.png](https://github.com/latvision/vision/releases/latest/download/latency.png)
+> If a release exists, links resolve; otherwise, links resolve after the first RC is published.
 
 This document defines the **official latency behavior** of the SDK for the
 0.1.x line. It is investor-grade and forms the basis of our SLO claims.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,24 @@
+# Releasing
+
+This document outlines how to cut a release candidate (RC) tag.
+
+## Cut an RC tag
+
+Run the following commands:
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only
+git tag -a v0.1.0-rc.2 -m "M1.1 RC drill"
+git push origin v0.1.0-rc.2
+```
+
+## Verify artifacts
+
+When the tag job runs, confirm it produces:
+
+- `bench/out/metrics.json`
+- `bench/out/stage_timings.csv`
+- `bench/out/latency.png` (optional)
+- `dist/*.whl`


### PR DESCRIPTION
## Summary
- document release candidate drill and artifact checks
- clarify latency doc RC artifact links
- add `release-rc` helper and metrics schema guard in RC workflow

## Testing
- `make release-rc`
- `make verify`

## Notes
- Attempted to open tracking issues but GitHub API requests failed (403).


------
https://chatgpt.com/codex/tasks/task_e_68bd234ef4bc8328b719fb154d108aa6