### PR TITLE
Add metrics hash tooling and calibration guard utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,3 +262,7 @@ release: clean build check
 release-rc:
 >@echo "git tag -a v0.1.0-rc.2 -m \"M1.1 RC drill\""
 >@echo "git push origin v0.1.0-rc.2"
+
+.PHONY: metrics-hash
+metrics-hash:
+>python scripts/write_metrics_hash.py

--- a/scripts/write_metrics_hash.py
+++ b/scripts/write_metrics_hash.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Compute a deterministic hash for canonical evaluation artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+_CANONICAL_PATHS = [
+    "bench/oracle_stats.json",
+    "bench/oracle_e2e.json",
+    "artifacts/config_precedence.json",
+    "artifacts/purity_report.json",
+]
+
+
+def _read_existing_bytes(paths: list[str]) -> bytes:
+    chunks: list[bytes] = []
+    for rel_path in paths:
+        path = Path(rel_path)
+        if path.exists():
+            chunks.append(path.read_bytes())
+    return b"".join(chunks)
+
+
+def main() -> None:
+    payload = _read_existing_bytes(_CANONICAL_PATHS)
+    digest = hashlib.sha256(payload).hexdigest()
+    os.makedirs("artifacts", exist_ok=True)
+    out_path = Path("artifacts/metrics_hash.txt")
+    out_path.write_text(f"metrics_hash: {digest}\n", encoding="utf-8")
+    print(f"metrics_hash: {digest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/latency_vision/calibration.py
+++ b/src/latency_vision/calibration.py
@@ -15,14 +15,26 @@ _T_MAX = 5.0
 def _as_array(values: object, *, dtype: DTypeLike | None = None) -> np.ndarray:
     """Coerce arbitrary 1D/2D-like inputs to an ndarray, with optional dtype."""
 
-    if isinstance(values, np.ndarray):
-        arr = values
-    elif isinstance(values, Iterable):
-        # Works for 1D (Iterable[float]) and 2D (Iterable[Iterable[float]])
-        arr = np.asarray(list(values))
-    else:
-        arr = np.asarray(values)
-    return arr.astype(dtype, copy=False) if dtype is not None else arr
+    arr = np.asarray(values, dtype=dtype)
+    if arr.ndim not in (1, 2):
+        raise ValueError("values must be 1-D or 2-D")
+
+    if arr.ndim == 2:
+        if arr.dtype == object:
+            width = arr.shape[1]
+            for row in arr:
+                try:
+                    row_len = len(row)
+                except TypeError as exc:  # pragma: no cover - defensive
+                    msg = "2-D inputs must have consistent row lengths"
+                    raise ValueError(msg) from exc
+                if row_len != width:
+                    raise ValueError("2-D inputs must have consistent row lengths")
+    elif arr.dtype == object and arr.size > 0:
+        if not all(np.isscalar(item) for item in arr):
+            raise ValueError("1-D inputs must be scalar-like")
+
+    return arr
 
 
 def distances_to_logits(d: np.ndarray | Iterable[float], method: str = "neg") -> np.ndarray:
@@ -133,10 +145,19 @@ class CalibrationReport:
     ece: float
 
 
+def unknown_rate_guard(flags: list[bool]) -> float:
+    """Return the fraction of truthy *flags*, guarding against empty inputs."""
+
+    if not flags:
+        return 0.0
+    return float(sum(flags)) / len(flags)
+
+
 __all__ = [
     "CalibrationReport",
     "distances_to_logits",
     "fit_temperature",
+    "unknown_rate_guard",
     "softmax",
     "temperature_scale",
 ]

--- a/src/vision/calibration.py
+++ b/src/vision/calibration.py
@@ -6,6 +6,7 @@ from latency_vision.calibration import (
     CalibrationReport,
     distances_to_logits,
     fit_temperature,
+    unknown_rate_guard,
     softmax,
     temperature_scale,
 )
@@ -14,6 +15,7 @@ __all__ = [
     "CalibrationReport",
     "distances_to_logits",
     "fit_temperature",
+    "unknown_rate_guard",
     "softmax",
     "temperature_scale",
 ]

--- a/tests/test_calibration_math.py
+++ b/tests/test_calibration_math.py
@@ -9,6 +9,7 @@ import numpy as np
 from vision.calibration import (
     distances_to_logits,
     fit_temperature,
+    unknown_rate_guard,
     softmax,
     temperature_scale,
 )
@@ -39,3 +40,8 @@ def test_fit_temperature_recovers_ground_truth() -> None:
     labels = np.argmax(scaled, axis=1)
     fitted = fit_temperature(logits, labels, seed=999)
     assert abs(fitted - true_T) < 0.3
+
+
+def test_unknown_rate_guard() -> None:
+    assert unknown_rate_guard([True, False, True, True]) == pytest.approx(0.75)
+    assert unknown_rate_guard([]) == 0.0


### PR DESCRIPTION
## Summary
- tighten `_as_array` validation in the calibration helpers and expose a reusable `unknown_rate_guard`
- re-export the guard through the compatibility shim and cover it with a unit test
- add a deterministic `metrics-hash` make target powered by `scripts/write_metrics_hash.py`

## Testing
- make type
- pytest tests/test_calibration_math.py


------
https://chatgpt.com/codex/tasks/task_e_68cedb0528b083288d9671edbfa15cda