### PR TITLE
Fix scalar error message in _as_array

### DIFF
--- a/src/latency_vision/calibration.py
+++ b/src/latency_vision/calibration.py
@@ -34,7 +34,7 @@ def _as_array(values: object, *, dtype: DTypeLike | None = None) -> np.ndarray:
                     raise ValueError("2-D inputs must have consistent row lengths")
     elif arr.dtype == object and arr.size > 0:
         if not all(np.isscalar(item) for item in arr):
-            raise ValueError("2-D inputs must have consistent row lengths")
+            raise ValueError("1-D inputs must be scalar-like")
 
     return arr
 


### PR DESCRIPTION
## Summary
- correct the ValueError message for 1-D object arrays in `_as_array`

## Testing
- make type
- pytest -q
- make metrics-hash

------
https://chatgpt.com/codex/tasks/task_e_68ceeaf29ad88328b1f4844d95d7fc80