### PR TITLE
chore(ci): add smoke verify job and pin ci threads

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -128,4 +128,9 @@ PY
           mypy src
           pytest -q
       - name: Import smoke
+        if: matrix.os != 'windows-latest'
+        run: python -c "import latency_vision as lv; print(getattr(lv,'__version__','unknown'))"
+      - name: Import smoke (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
         run: python -c "import latency_vision as lv; print(getattr(lv,'__version__','unknown'))"


### PR DESCRIPTION
## Summary
- pin thread-related environment variables for the verify workflow and ensure strace is installed
- add a cross-OS verify-smoke workflow that runs the lightweight make verify and import smoke checks

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cf30163ed88328ad20c24dd5477c88