### PR TITLE
Add supply-chain guardrails and promotion sanity check

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -80,6 +80,8 @@ jobs:
           pip install -e .
       - name: Run prove pipeline
         run: make prove
+      - name: Promotion sanity
+        run: make kb-promote
       - name: Unknowns guard
         run: make unknowns-guard
       - name: Public API freeze
@@ -104,9 +106,11 @@ jobs:
             artifacts/metrics_hash.txt
             artifacts/metrics_hash_payload.json
             artifacts/purity_report.json
+            artifacts/purity_offenders.txt
             artifacts/sbom.json
             artifacts/licenses.json
             artifacts/wheels_hashes.txt
+            artifacts/promotion_report.json
             gate_summary.txt
 
   smoke:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 SHELL := /usr/bin/env bash
 .SHELLFLAGS := -eu -o pipefail -c
 
-.PHONY: eval-pack bench slo-check metrics-hash purity supplychain prove unknowns-guard api-freeze schema-bump
+.PHONY: eval-pack bench slo-check metrics-hash purity supplychain prove unknowns-guard api-freeze schema-bump kb-promote
 
 FIXTURE_BANK := bench/fixtures/bank.jsonl
 FIXTURE_QUERIES := bench/fixtures/queries.jsonl
@@ -39,6 +39,10 @@ purity:
 supplychain:
 	set -euo pipefail
 	PYTHONPATH="src${PYTHONPATH:+:${PYTHONPATH}}" python scripts/supplychain.py
+
+kb-promote:
+	set -euo pipefail
+	PYTHONPATH="src${PYTHONPATH:+:${PYTHONPATH}}" python scripts/kb_promote.py
 
 
 prove:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,6 @@ tomli>=2.0.1 ; python_version < "3.11"
 numpy>=1.26,<3
 pillow>=10,<11
 matplotlib>=3.8,<3.10
+pip-licenses>=4.5
+pipdeptree>=2.13
+cyclonedx-bom>=4.0 ; python_version >= "3.10"

--- a/scripts/kb_promote.py
+++ b/scripts/kb_promote.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: Apache-2.0
 """Promotion sanity gate to prevent junk from landing in KB."""
+
 from __future__ import annotations
 
 import json

--- a/scripts/kb_promote.py
+++ b/scripts/kb_promote.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# SPDX-License-Identifier: Apache-2.0
+"""Promotion sanity gate to prevent junk from landing in KB."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+LEDGER = Path("logs/evidence_ledger.jsonl")
+OUT = Path("artifacts/promotion_report.json")
+
+CUTOFF = 0.5
+
+
+def main() -> int:
+    OUT.parent.mkdir(exist_ok=True)
+    promotions: list[dict] = []
+    reasons: list[dict] = []
+
+    if not LEDGER.exists():
+        OUT.write_text(
+            json.dumps({"promotions": [], "reasons": [{"reason": "no-ledger"}]}, indent=2),
+            encoding="utf-8",
+        )
+        print("no ledger; zero promotions")
+        return 0
+
+    with LEDGER.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            is_unknown = bool(row.get("is_unknown_truth", False))
+            score = float(row.get("score", 0.0))
+
+            if is_unknown:
+                reasons.append({"query_id": row.get("query_id"), "reason": "unknown-truth"})
+                continue
+
+            if score < CUTOFF:
+                reasons.append({"query_id": row.get("query_id"), "reason": f"score<{CUTOFF}"})
+                continue
+
+            promotions.append(
+                {
+                    "query_id": row.get("query_id"),
+                    "picked_qid": row.get("picked_qid"),
+                    "score": score,
+                }
+            )
+
+    OUT.write_text(
+        json.dumps({"promotions": promotions, "reasons": reasons}, indent=2),
+        encoding="utf-8",
+    )
+    print(f"promotions: {len(promotions)}; refusals: {len(reasons)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/supplychain.py
+++ b/scripts/supplychain.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # SPDX-License-Identifier: Apache-2.0
 """Supply-chain guardrail: SBOM, licenses, and wheel hashes."""
+
 from __future__ import annotations
 
 import hashlib

--- a/scripts/supplychain.py
+++ b/scripts/supplychain.py
@@ -1,134 +1,84 @@
 #!/usr/bin/env python
-"""Emit deterministic supply-chain artifacts for the prove pipeline."""
-
+# SPDX-License-Identifier: Apache-2.0
+"""Supply-chain guardrail: SBOM, licenses, and wheel hashes."""
 from __future__ import annotations
 
 import hashlib
 import json
-from importlib import metadata
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 
-from latency_vision.schemas import SCHEMA_VERSION
+ART = Path("artifacts")
+ART.mkdir(exist_ok=True)
 
-ROOT = Path(__file__).resolve().parent.parent
-ARTIFACTS = ROOT / "artifacts"
-
-
-def _normalize_name(name: str) -> str:
-    return name.replace("_", "-").lower()
+ALLOW = {"Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "MIT", "PSF-2.0"}
 
 
-def _iter_distributions() -> list[metadata.Distribution]:
-    unique: dict[str, metadata.Distribution] = {}
-    for dist in metadata.distributions():
-        name = dist.metadata.get("Name")
-        if not name:
-            continue
-        key = _normalize_name(str(name))
-        unique.setdefault(key, dist)
-    return [unique[key] for key in sorted(unique)]
+def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=True, text=True, capture_output=True)
 
 
-def _extract_license(dist: metadata.Distribution) -> str:
-    meta = dist.metadata
-    license_field = (meta.get("License") or "").strip()
-    if license_field and license_field.upper() != "UNKNOWN":
-        return license_field
-    classifiers = meta.get_all("Classifier", []) or []
-    for classifier in classifiers:
-        if classifier.startswith("License ::"):
-            candidate = classifier.split("::")[-1].strip()
-            if candidate:
-                return candidate
-    return "UNKNOWN"
+def write(path: Path, data: str) -> None:
+    path.write_text(data if data.endswith("\n") else data + "\n", encoding="utf-8")
 
 
-def _extract_homepage(dist: metadata.Distribution) -> str:
-    return (dist.metadata.get("Home-page") or "").strip()
+def sbom() -> None:
+    """Emit an SBOM for the current environment."""
+
+    try:
+        out = run([sys.executable, "-m", "cyclonedx_py", "-e"]).stdout
+    except Exception:
+        out = run([sys.executable, "-m", "pipdeptree", "--json-tree"]).stdout
+    write(ART / "sbom.json", out)
 
 
-def _hash_file(path: Path) -> bytes:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(8192), b""):
-            digest.update(chunk)
-    return digest.digest()
+def licenses() -> list[dict]:
+    """Capture license metadata for all installed packages."""
+
+    out = run([sys.executable, "-m", "piplicenses", "--format=json"]).stdout
+    data: list[dict] = json.loads(out)
+    write(ART / "licenses.json", json.dumps(data, indent=2, sort_keys=True))
+    return data
 
 
-def _hash_distribution(dist: metadata.Distribution) -> str:
-    digest = hashlib.sha256()
-    files = dist.files or []
-    for file in sorted(files, key=lambda item: str(item)):
-        resolved = Path(dist.locate_file(file))
-        digest.update(str(file).encode("utf-8"))
-        digest.update(b"\0")
-        if resolved.is_file():
-            digest.update(_hash_file(resolved))
-    return digest.hexdigest()
-
-
-def _collect_requirements(dist: metadata.Distribution) -> list[str]:
-    requires = dist.requires or []
-    return sorted(str(req) for req in requires)
-
-
-def main() -> None:
-    ARTIFACTS.mkdir(parents=True, exist_ok=True)
-    distributions = _iter_distributions()
-
-    packages: list[dict[str, object]] = []
-    notices: list[dict[str, object]] = []
-    wheel_lines: list[str] = []
-
-    for dist in distributions:
-        raw_name = (
-            dist.metadata.get("Name")
-            or dist.metadata.get("Summary")
-            or dist.metadata.get("Metadata-Version")
-            or "package"
+def enforce_allowlist(rows: list[dict]) -> None:
+    bad: list[tuple[str, str]] = []
+    for row in rows:
+        license_name = (row.get("License") or "").strip()
+        name = row.get("Name") or row.get("name") or "UNKNOWN"
+        if license_name not in ALLOW:
+            bad.append((str(name), license_name))
+    if bad:
+        msg = "Disallowed licenses:\n" + "\n".join(
+            f"  {name}: {license_name or 'Unknown'}" for name, license_name in bad
         )
-        name = str(raw_name)
-        version = str(dist.version)
-        license_name = _extract_license(dist)
-        homepage = _extract_homepage(dist)
-        requires = _collect_requirements(dist)
-        packages.append(
-            {
-                "name": name,
-                "version": version,
-                "license": license_name,
-                "homepage": homepage,
-                "requires": requires,
-            }
-        )
-        notices.append(
-            {
-                "name": name,
-                "version": version,
-                "license": license_name,
-                "homepage": homepage,
-            }
-        )
-        wheel_lines.append(f"{name}=={version} sha256={_hash_distribution(dist)}")
+        print(msg, file=sys.stderr)
+        raise SystemExit(2)
 
-    sbom = {
-        "schema_version": SCHEMA_VERSION,
-        "packages": packages,
-    }
-    (ARTIFACTS / "sbom.json").write_text(
-        json.dumps(sbom, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
 
-    licenses = {
-        "schema_version": SCHEMA_VERSION,
-        "notices": notices,
-    }
-    (ARTIFACTS / "licenses.json").write_text(
-        json.dumps(licenses, indent=2, sort_keys=True) + "\n", encoding="utf-8"
-    )
+def wheels_hashes() -> None:
+    """Download wheels for the environment and produce deterministic hashes."""
 
-    (ARTIFACTS / "wheels_hashes.txt").write_text("\n".join(wheel_lines) + "\n", encoding="utf-8")
+    with tempfile.TemporaryDirectory() as tmp:
+        run([sys.executable, "-m", "pip", "download", "--only-binary", ":all:", "-d", tmp])
+        lines: list[str] = []
+        directory = Path(tmp)
+        for wheel in sorted(directory.iterdir()):
+            digest = hashlib.sha256(wheel.read_bytes()).hexdigest()
+            lines.append(f"{wheel.name}  sha256:{digest}")
+        write(ART / "wheels_hashes.txt", "\n".join(lines))
+
+
+def main() -> int:
+    sbom()
+    rows = licenses()
+    enforce_allowlist(rows)
+    wheels_hashes()
+    print("supply-chain ok")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/supplychain.py
+++ b/scripts/supplychain.py
@@ -5,16 +5,96 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.metadata as importlib_metadata
 import json
+import re
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
+from typing import Any, NamedTuple
 
 ART = Path("artifacts")
 ART.mkdir(exist_ok=True)
 
-ALLOW = {"Apache-2.0", "BSD-2-Clause", "BSD-3-Clause", "ISC", "MIT", "PSF-2.0"}
+ALLOW = {
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "PSF-2.0",
+    "HPND",
+    "Unlicense",
+}
+
+EXACT_ALIASES = {
+    "apache license 2.0": "Apache-2.0",
+    "apache 2.0": "Apache-2.0",
+    "apache license, version 2.0": "Apache-2.0",
+    "apache software license": "Apache-2.0",
+    "apache license version 2.0": "Apache-2.0",
+    "apache software license version 2.0": "Apache-2.0",
+    "apache software licence": "Apache-2.0",
+    "apache software licence version 2.0": "Apache-2.0",
+    "apache-2.0": "Apache-2.0",
+    "bsd": "BSD-3-Clause",
+    "bsd license": "BSD-3-Clause",
+    "bsd-2-clause": "BSD-2-Clause",
+    "bsd 2-clause": "BSD-2-Clause",
+    "bsd-3-clause": "BSD-3-Clause",
+    "bsd 3-clause": "BSD-3-Clause",
+    "historical permission notice and disclaimer": "HPND",
+    "hpnd": "HPND",
+    "isc": "ISC",
+    "isc license": "ISC",
+    "isc license (iscl)": "ISC",
+    "mit": "MIT",
+    "mit license": "MIT",
+    "mozilla public license 2.0": "MPL-2.0",
+    "mpl 2.0": "MPL-2.0",
+    "mpl-2.0": "MPL-2.0",
+    "python software foundation license": "PSF-2.0",
+    "python software foundation license (psf-2.0)": "PSF-2.0",
+    "psf": "PSF-2.0",
+    "psf license": "PSF-2.0",
+    "python software foundation": "PSF-2.0",
+    "the unlicense": "Unlicense",
+    "unlicense": "Unlicense",
+}
+
+SUBSTRING_ALIASES = (
+    ("apache", "Apache-2.0"),
+    ("bsd-2", "BSD-2-Clause"),
+    ("bsd 2", "BSD-2-Clause"),
+    ("bsd-3", "BSD-3-Clause"),
+    ("bsd 3", "BSD-3-Clause"),
+    ("bsd", "BSD-3-Clause"),
+    ("historical permission notice and disclaimer", "HPND"),
+    ("hpnd", "HPND"),
+    ("gnu general public license", "GPL"),
+    ("gnu lesser general public license", "LGPL"),
+    ("isc", "ISC"),
+    ("mit", "MIT"),
+    ("mozilla public license", "MPL-2.0"),
+    ("mpl", "MPL-2.0"),
+    ("python software foundation", "PSF-2.0"),
+    ("psf", "PSF-2.0"),
+    ("unlicense", "Unlicense"),
+)
+
+LICENSE_SPLIT_RE = re.compile(r"[\\/,;]|\s+and\s+|\s+or\s+", re.IGNORECASE)
+
+
+class PackageReport(NamedTuple):
+    """Summary of a package's declared and canonical license information."""
+
+    name: str
+    version: str
+    declared: tuple[str, ...]
+    canonical: tuple[str, ...]
 
 
 def run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
@@ -35,26 +115,88 @@ def sbom() -> None:
     write(ART / "sbom.json", out)
 
 
-def licenses() -> list[dict]:
-    """Capture license metadata for all installed packages."""
+def _split_licenses(value: str) -> list[str]:
+    value = value.replace("(", " ").replace(")", " ")
+    parts = [p.strip() for p in LICENSE_SPLIT_RE.split(value) if p.strip()]
+    return parts or ([value.strip()] if value.strip() else [])
 
-    out = run([sys.executable, "-m", "piplicenses", "--format=json"]).stdout
-    data: list[dict] = json.loads(out)
+
+def _canonicalize(entry: str) -> str | None:
+    normalized = re.sub(r"\s+", " ", entry.strip().lower()).replace("licence", "license")
+    if not normalized:
+        return None
+    if normalized in EXACT_ALIASES:
+        return EXACT_ALIASES[normalized]
+    for needle, alias in SUBSTRING_ALIASES:
+        if needle in normalized:
+            return alias
+    return None
+
+
+def _distribution_report(dist: importlib_metadata.Distribution) -> PackageReport:
+    name = dist.metadata.get("Name") or dist.metadata["Name"]
+    declared: set[str] = set()
+    license_field = dist.metadata.get("License")
+    if license_field:
+        declared.update(_split_licenses(license_field))
+    for classifier in dist.metadata.get_all("Classifier") or []:
+        if not classifier.lower().startswith("license ::"):
+            continue
+        declared.add(classifier.split("::")[-1].strip())
+    canonical: set[str] = {
+        alias for item in declared if (alias := _canonicalize(item))
+    }
+    if not canonical and license_field:
+        fallback = _canonicalize(license_field)
+        if fallback:
+            canonical.add(fallback)
+    return PackageReport(
+        name=name,
+        version=dist.version,
+        declared=tuple(sorted(declared)),
+        canonical=tuple(sorted(alias for alias in canonical if alias)),
+    )
+
+
+def licenses() -> list[dict[str, Any]]:
+    """Capture license metadata for installed packages and normalize it."""
+
+    reports: list[PackageReport] = []
+    for dist in importlib_metadata.distributions():
+        reports.append(_distribution_report(dist))
+    reports.sort(key=lambda item: item.name.lower())
+    data = [
+        {
+            "name": report.name,
+            "version": report.version,
+            "declared_licenses": list(report.declared),
+            "canonical_licenses": list(report.canonical),
+        }
+        for report in reports
+    ]
     write(ART / "licenses.json", json.dumps(data, indent=2, sort_keys=True))
     return data
 
 
-def enforce_allowlist(rows: list[dict]) -> None:
-    bad: list[tuple[str, str]] = []
+def enforce_allowlist(rows: Iterable[dict[str, Any]]) -> None:
+    bad: list[tuple[str, list[str]]] = []
     for row in rows:
-        license_name = (row.get("License") or "").strip()
-        name = row.get("Name") or row.get("name") or "UNKNOWN"
-        if license_name not in ALLOW:
-            bad.append((str(name), license_name))
+        name = row.get("name") or row.get("Name") or "UNKNOWN"
+        canonical = [str(item) for item in row.get("canonical_licenses") or []]
+        declared = row.get("declared_licenses") or []
+        declared_list = [str(item) for item in declared] if declared else ["Unknown"]
+        if not canonical:
+            bad.append((str(name), declared_list))
+            continue
+        disallowed = [lic for lic in canonical if lic not in ALLOW]
+        if disallowed:
+            bad.append((str(name), disallowed))
     if bad:
-        msg = "Disallowed licenses:\n" + "\n".join(
-            f"  {name}: {license_name or 'Unknown'}" for name, license_name in bad
-        )
+        lines = []
+        for name, issues in bad:
+            issues_text = ", ".join(issues)
+            lines.append(f"  {name}: {issues_text or 'Unknown'}")
+        msg = "Disallowed licenses:\n" + "\n".join(lines)
         print(msg, file=sys.stderr)
         raise SystemExit(2)
 


### PR DESCRIPTION
## Summary
- fail the purity guard when network syscalls appear and persist an offenders list alongside the report
- replace the supply-chain script with SBOM generation, license allowlisting, and deterministic wheel hash capture plus add promotion sanity plumbing
- wire the new promotion guard into the Makefile/workflow and ensure required tooling is available in development requirements

## Testing
- make kb-promote
- make supplychain *(fails: cyclonedx/pipdeptree unavailable in offline container)*


------
https://chatgpt.com/codex/tasks/task_e_68d1b76c5f3083289075b21f25869da9