### PR TITLE
Add supply-chain policy and KB promotion guard

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -80,6 +80,8 @@ jobs:
           pip install -e .
       - name: Run prove pipeline
         run: make prove
+      - name: KB promote sanity
+        run: make kb-promote
       - name: Unknowns guard
         run: make unknowns-guard
       - name: Public API freeze
@@ -104,9 +106,11 @@ jobs:
             artifacts/metrics_hash.txt
             artifacts/metrics_hash_payload.json
             artifacts/purity_report.json
+            artifacts/purity_offenders.txt
             artifacts/sbom.json
             artifacts/licenses.json
             artifacts/wheels_hashes.txt
+            artifacts/promotion_report.json
             gate_summary.txt
 
   smoke:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 SHELL := /usr/bin/env bash
 .SHELLFLAGS := -eu -o pipefail -c
 
-.PHONY: eval-pack bench slo-check metrics-hash purity supplychain prove unknowns-guard api-freeze schema-bump
+.PHONY: eval-pack bench slo-check metrics-hash purity supplychain kb-promote prove unknowns-guard api-freeze schema-bump
 
 FIXTURE_BANK := bench/fixtures/bank.jsonl
 FIXTURE_QUERIES := bench/fixtures/queries.jsonl
@@ -39,6 +39,11 @@ purity:
 supplychain:
 	set -euo pipefail
 	PYTHONPATH="src${PYTHONPATH:+:${PYTHONPATH}}" python scripts/supplychain.py
+
+
+kb-promote:
+	set -euo pipefail
+	PYTHONPATH="src${PYTHONPATH:+:${PYTHONPATH}}" python scripts/kb_promote.py
 
 
 prove:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,9 @@ ruff~=0.4
 pre-commit>=3.7,<4
 build
 cibuildwheel
+pip-licenses>=4.5
+pipdeptree>=2.13
+cyclonedx-bom>=4.0 ; python_version >= "3.10"
 jsonschema>=4.21
 tomli>=2.0.1 ; python_version < "3.11"
 numpy>=1.26,<3

--- a/scripts/kb_promote.py
+++ b/scripts/kb_promote.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""Promote knowledge base entries from the evidence ledger."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+CUTOFF = 0.5
+ROOT = Path(__file__).resolve().parent.parent
+LEDGER_PATH = ROOT / "logs" / "evidence_ledger.jsonl"
+ARTIFACTS = ROOT / "artifacts"
+REPORT_PATH = ARTIFACTS / "promotion_report.json"
+
+
+def _coerce_score(value: Any) -> float | None:
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return None
+    if score != score:  # NaN guard
+        return None
+    return score
+
+
+def _load_ledger() -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    with LEDGER_PATH.open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError as error:  # pragma: no cover - input contract
+                raise SystemExit(
+                    f"failed to parse ledger line {line_number}: {error.msg}"
+                ) from error
+            if not isinstance(entry, dict):  # pragma: no cover - schema guard
+                raise SystemExit(f"ledger line {line_number} is not an object")
+            entries.append(entry)
+    return entries
+
+
+def main() -> None:
+    ARTIFACTS.mkdir(parents=True, exist_ok=True)
+
+    if not LEDGER_PATH.exists():
+        report = {
+            "promotions": [],
+            "reasons": [
+                {
+                    "query_id": None,
+                    "reason": "no-ledger",
+                }
+            ],
+        }
+        REPORT_PATH.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print("promotions: 0; refusals: 1")
+        return
+
+    ledger_rows = _load_ledger()
+
+    promotions: list[dict[str, Any]] = []
+    reasons: list[dict[str, Any]] = []
+
+    for row in ledger_rows:
+        query_id = row.get("query_id")
+        picked_qid = row.get("picked_qid")
+        score_value = _coerce_score(row.get("score"))
+        if bool(row.get("is_unknown_truth")):
+            reasons.append({"query_id": query_id, "reason": "unknown-truth"})
+            continue
+        if score_value is None or score_value < CUTOFF:
+            reasons.append({"query_id": query_id, "reason": "score<0.5"})
+            continue
+        promotions.append(
+            {
+                "query_id": query_id,
+                "picked_qid": picked_qid,
+                "score": score_value,
+            }
+        )
+
+    report = {"promotions": promotions, "reasons": reasons}
+    REPORT_PATH.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"promotions: {len(promotions)}; refusals: {len(reasons)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/purity_guard.sh
+++ b/scripts/purity_guard.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
+mkdir -p artifacts
+
 if ! command -v strace >/dev/null 2>&1; then
     if [ "$(uname -s)" != "Linux" ]; then
         echo "purity guard requires strace or a POSIX socket hook; aborting." >&2
@@ -11,5 +13,22 @@ if ! command -v strace >/dev/null 2>&1; then
     fi
 fi
 
+set +e
 PYTHONPATH="${REPO_ROOT}/src${PYTHONPATH:+:${PYTHONPATH}}" \
     python scripts/run_sandboxed.py --report artifacts/purity_report.json -- make bench
+status=$?
+set -e
+
+jq -r '.offending[]? | "\(.event)  \(.detail)"' artifacts/purity_report.json \
+    > artifacts/purity_offenders.txt || true
+
+if [ "$status" -ne 0 ]; then
+    exit "$status"
+fi
+
+if jq -e '.network_syscalls == true' artifacts/purity_report.json >/dev/null 2>&1; then
+    echo "network syscalls detected; see artifacts/purity_offenders.txt" >&2
+    exit 1
+fi
+
+echo "purity ok"


### PR DESCRIPTION
## Summary
- Harden the purity guard to capture offending syscalls and fail the pipeline if network access occurs.
- Replace the supply-chain script with SBOM generation, license allow-list enforcement, and deterministic wheel hash output.
- Add the kb promotion sanity check, wire it into the Makefile and CI workflow, and upload the new artifacts.

## Testing
- ruff check scripts/supplychain.py scripts/kb_promote.py
- make kb-promote

------
https://chatgpt.com/codex/tasks/task_e_68d1c72f56608328bc6d285c9d5326b2