### PR TITLE
ci: purge stale latency wheels

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,6 +25,17 @@ jobs:
         python-version: ['3.10', '3.11']
     steps:
       - uses: actions/checkout@v4
+      - name: Purge stale site-packages (latency_vision*)
+        shell: bash
+        run: |
+          python - <<'PY'
+          import pathlib, shutil, site, sys
+          roots = set(site.getsitepackages() + [site.getusersitepackages()])
+          for root in filter(None, roots):
+              for p in pathlib.Path(root).glob("latency_vision*"):
+                  print("removing", p, file=sys.stderr)
+                  shutil.rmtree(p, ignore_errors=True)
+          PY
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -61,6 +72,17 @@ jobs:
       NUMEXPR_NUM_THREADS: "1"
     steps:
       - uses: actions/checkout@v4
+      - name: Purge stale site-packages (latency_vision*)
+        shell: bash
+        run: |
+          python - <<'PY'
+          import pathlib, shutil, site, sys
+          roots = set(site.getsitepackages() + [site.getusersitepackages()])
+          for root in filter(None, roots):
+              for p in pathlib.Path(root).glob("latency_vision*"):
+                  print("removing", p, file=sys.stderr)
+                  shutil.rmtree(p, ignore_errors=True)
+          PY
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -123,6 +145,17 @@ jobs:
         python-version: ['3.11']
     steps:
       - uses: actions/checkout@v4
+      - name: Purge stale site-packages (latency_vision*)
+        shell: bash
+        run: |
+          python - <<'PY'
+          import pathlib, shutil, site, sys
+          roots = set(site.getsitepackages() + [site.getusersitepackages()])
+          for root in filter(None, roots):
+              for p in pathlib.Path(root).glob("latency_vision*"):
+                  print("removing", p, file=sys.stderr)
+                  shutil.rmtree(p, ignore_errors=True)
+          PY
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- purge any cached latency_vision wheels from site-packages before installing dependencies in CI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2cd91ddf08328892ef9f6d255cb43